### PR TITLE
Simplify home and About pages

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -11,25 +11,8 @@ I earned my bachelor’s degree in computer science from [Shanghai Jiao Tong Uni
 
 [sjtu]: http://en.sjtu.edu.cn/  
 [cmu]: https://www.cs.cmu.edu/  
+[neon]: https://neon.tech  
 
 I go by any combination of *Alex*, *Chi*, and *Zhang*. You can call me Alex Chi, Chi Zhang, Alex Chi Z., Chi (Alex) Zhang, or simply Chi.
 
-During my undergraduate and graduate studies, I specialized in building system software, with a particular focus on database systems. I developed [AgateDB][agatedb] during my internship at PingCAP, worked on [TerarkDB][terarkdb] for Zoned Namespace SSDs at ByteDance, and contributed to the early development of [RisingWave][risingwave] at RisingWave Labs (formerly Singularity Data) as a founding member of the company. In the summer of 2023, I interned at [Neon][neon], which offers fully managed Postgres services, and have continued working there as a full-time engineer after graduation.
-
-[agatedb]: https://github.com/tikv/agatedb    
-[terarkdb]: https://github.com/bytedance/terarkdb  
-
-I’m passionate about engaging with the open-source community. Currently, I’m a maintainer for the [TiKV project][tikv] and also manage several widely used projects such as SJTUG mirror and SJTUThesis in the [SJTUG community][sjtug]. To help more students learn about database systems, I co-developed an educational OLAP database called [RisingLight][risinglight]. The SQL layer of RisingLight was later integrated into [BusTub](https://github.com/cmu-db/bustub), the course project for CMU’s 15-445/645 Database Systems class, transforming BusTub into a functional SQL database system.
-
-[tikv]: https://tikv.org  
-[sjtug]: https://github.com/sjtug  
-[risinglight]: https://github.com/risinglightdb/risinglight      
-[risingwave]: https://github.com/singularity-data/risingwave  
-[neon]: https://neon.tech  
-
-I’m also interested in developing educational resources on database systems. I have created two tutorials for using Rust in data-intensive applications: [type-exercise-in-rust](https://github.com/skyzh/type-exercise-in-rust) teaches how to build a vectorized expression evaluation framework within database systems, while [mini-lsm](https://github.com/skyzh/mini-lsm) provides guidance on building an LSM-tree storage engine. I served as a teaching assistant for CMU-DB’s BusTub database system for three semesters, where I designed the SQL query frontend for the [query processing project](https://15445.courses.cs.cmu.edu/fall2022/project3/) and the [MVCC project](https://15445.courses.cs.cmu.edu/fall2023/project4/) based on HyPer. With my experience with the BusTub system, I authored the [write-you-a-vector-db](https://github.com/skyzh/write-you-a-vector-db) tutorial on adding vector capabilities to a relational database system. Recently, I developed a course on building an LLM serving infrastructure called [tiny-llm](https://github.com/skyzh/tiny-llm).
-
-Looking ahead, I am always seeking opportunities to build reliable and efficient systems that excite me and inspire people.
-
 </Layout>
-

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -12,47 +12,9 @@ Member of Technical Staff at the [Lakebase](https://neon.tech) team in Databrick
 * <a href={CV_URL}>Curriculum Vitae</a>
 * [Blog](/blog/)
 
-## FAQ
-
-**Q: How do you pronounce your first name, *Chi*, and your last name, *Zhang*?** \
-A: In the English context, *Chi* is usually pronounced /tʃiː/ (like "chi" in "cheese" without the "se"). You can find the Mandarin pronunciation in [this video](https://www.youtube.com/watch?v=xTU2n22G6kc) (2nd tone). *Zhang* is often pronounced like "John."
-
-**Q: Why are you based in Pittsburgh instead of SF/SEA/NYC?** \
-A: After studying for one and a half years at Carnegie Mellon University in Pittsburgh, I chose to work remotely from here. The cost of living is lower compared to SF/NYC, and I enjoy the peaceful, slow-paced lifestyle. \
-**Update:** I'm planning to move to Mountain View or Seattle in late 2025 or early 2026 as part of the Neon-Databricks acquisition.
-
-**Q: What languages do you speak?** \
-A: I speak Mandarin Chinese, English, and Shanghainese, a dialect of Shanghai. I also know some Japanese. 你好 / 今朝夜到恰老酒伐 / 日本語は少し分かります / Hello!
-
-**Q: What is your favorite programming language?** \
-A: Rust. I started learning it in 2018 and have used it ever since.
-
-**Q: When did you start programming?** \
-A: I started programming in 2009 during primary school. I spent several years in competitive programming in junior middle and high school. Afterward, I shifted my focus to systems programming and database systems. My first language was BASIC, followed by C. I then learned Ruby (because RPG Maker used it for scripting), and later PHP, JavaScript, C++, Python, Haskell, Rust, and Go.
-
-**Q: When did you start working on databases?** \
-A: My database journey began in 2020 when I submitted my first patch to TiKV as part of the LFX Mentorship project (similar to GSoC). Since then, I've focused on databases and storage systems. I consolidated what I have learned throughout the journey and developed a course on building a storage engine from scratch: check out [mini-lsm](https://github.com/skyzh/mini-lsm).
-
-**Q: When will you update your blog (and the courses)?** \
-A: I'll try to update them when I have some free time 🫠. In the meantime, you can join the Discord communities for my courses to get quick answers to small questions.
-
-**Q: Can you offer advice for new grads pursuing a career in databases?** \
-A: Certainly! Feel free to reach out to me, but please know I might be slow to respond.
-
-**Q: What is the best bubble tea shop in Pittsburgh?** \
-A: Tsaocaa has a location near the University of Pittsburgh and another in Squirrel Hill. The newly opened Wushiland is also fantastic. \
-**Update:** There are a few new bubble tea spots in Squirrel Hill, and I now recommend Tiger Sugar. Tsaocaa remains on my list, but it's now my second choice.
-
-**Q: Why does [15-445/645](https://15445.courses.cs.cmu.edu/) (the CMU database course) seem more challenging since you became a TA in 2022?** \
-A: We've been enhancing the projects to make them more engaging and less painful, removing outdated materials, and adding new, industry-relevant content. Except for the Fall 2023 semester, when I proposed too many ambitious ideas, the overall difficulty has stayed consistent.
-
-**Q: Are you planning to go all-in on the AI/LLM hype?** \
-A: Not yet, but I'm interested in learning how LLMs work and exploring system optimizations to improve model inference and serving. I've also developed a new course about it called [tiny-llm](https://github.com/skyzh/tiny-llm).
-
 ## Find me on
 
 * Email: `iskyzh at gmail dot com`
 * [GitHub](https://github.com/skyzh)
 * [LinkedIn](https://www.linkedin.com/in/alex-chi-skyzh/)
 * [Twitter](https://twitter.com/iskyzh)
-* [Zhihu](https://www.zhihu.com/people/skyzh)


### PR DESCRIPTION
## What changed

- Removed the FAQ section from the homepage.
- Removed the Zhihu link from the contact list.
- Reduced the About page to its first two paragraphs while preserving the link definitions they use.

## Why

The personal content is being simplified ahead of a future rewrite and broader visual refresh.

## Impact

Existing page, blog, tag, feed, API, and legacy routes remain unchanged.

## Validation

- `npm run build`
- Served the production build locally with `npm run preview -- --host 127.0.0.1`
- Audited all 133 generated HTML, JSON, and XML routes; every route returned HTTP 200.
