### PR TITLE
A Good Memo Table Is Hard to Build

### DIFF
--- a/public/blog/2026-08-08-optimizer-lesson-02/01-canonicalization.svg
+++ b/public/blog/2026-08-08-optimizer-lesson-02/01-canonicalization.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 650" role="img" aria-labelledby="title desc">
+  <title id="title">Expression keys before and after child-group canonicalization</title>
+  <desc id="desc">Before the merge, two Project x expressions refer to different scan groups. After group G2 redirects to G1, canonicalizing the second Project changes its key so both Projects are identical, which requires their owner groups G3 and G4 to merge.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#334155"/>
+    </marker>
+    <style>
+      .title{font:700 28px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.label{font:700 18px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.body{font:16px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#334155}.code{font:16px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#0f172a}.small{font:14px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#475569}.group{fill:#f8fafc;stroke:#64748b;stroke-width:2;stroke-dasharray:7 5}.expr{fill:#ffffff;stroke:#334155;stroke-width:2}.merge{fill:#fef3c7;stroke:#d97706;stroke-width:3}.ok{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.edge{stroke:#334155;stroke-width:2;fill:none;marker-end:url(#arrow)}.redirect{stroke:#d97706;stroke-width:3;fill:none;stroke-dasharray:8 6;marker-end:url(#arrow)}
+    </style>
+  </defs>
+  <rect width="1200" height="650" fill="#ffffff"/>
+  <text x="600" y="42" text-anchor="middle" class="title">Canonical child IDs change expression identity</text>
+
+  <rect x="28" y="70" width="548" height="530" rx="18" fill="#f8fafc" stroke="#cbd5e1"/>
+  <text x="52" y="106" class="label">Before merging G2 into G1</text>
+  <text x="52" y="133" class="body">Different child IDs produce different hash keys.</text>
+
+  <rect x="72" y="180" width="200" height="112" rx="14" class="group"/>
+  <text x="172" y="206" text-anchor="middle" class="label">G3</text>
+  <rect x="92" y="222" width="160" height="48" rx="9" class="expr"/>
+  <text x="172" y="252" text-anchor="middle" class="code">Project[x](!G1)</text>
+
+  <rect x="332" y="180" width="200" height="112" rx="14" class="group"/>
+  <text x="432" y="206" text-anchor="middle" class="label">G4</text>
+  <rect x="352" y="222" width="160" height="48" rx="9" class="expr"/>
+  <text x="432" y="252" text-anchor="middle" class="code">Project[x](!G2)</text>
+
+  <path d="M172 270 C172 330,150 350,150 388" class="edge"/>
+  <path d="M432 270 C432 330,454 350,454 388" class="edge"/>
+
+  <rect x="72" y="390" width="156" height="96" rx="14" class="group"/>
+  <text x="150" y="416" text-anchor="middle" class="label">G1</text>
+  <rect x="91" y="430" width="118" height="38" rx="8" class="expr"/>
+  <text x="150" y="455" text-anchor="middle" class="code">Scan(t1)</text>
+
+  <rect x="376" y="390" width="156" height="96" rx="14" class="group"/>
+  <text x="454" y="416" text-anchor="middle" class="label">G2</text>
+  <rect x="395" y="430" width="118" height="38" rx="8" class="expr"/>
+  <text x="454" y="455" text-anchor="middle" class="code">Scan(alias)</text>
+
+  <text x="302" y="545" text-anchor="middle" class="code">key = operator + canonical child groups + private data</text>
+
+  <rect x="624" y="70" width="548" height="530" rx="18" fill="#fffaf0" stroke="#f59e0b"/>
+  <text x="648" y="106" class="label">After G2 redirects to G1</text>
+  <text x="648" y="133" class="body">Canonicalization reveals a collision that redirects alone cannot repair.</text>
+
+  <rect x="672" y="180" width="200" height="112" rx="14" class="group"/>
+  <text x="772" y="206" text-anchor="middle" class="label">G3</text>
+  <rect x="692" y="222" width="160" height="48" rx="9" class="merge"/>
+  <text x="772" y="252" text-anchor="middle" class="code">Project[x](!G1)</text>
+
+  <rect x="932" y="180" width="200" height="112" rx="14" class="group"/>
+  <text x="1032" y="206" text-anchor="middle" class="label">G4</text>
+  <rect x="952" y="222" width="160" height="48" rx="9" class="merge"/>
+  <text x="1032" y="252" text-anchor="middle" class="code">Project[x](!G1)</text>
+
+  <path d="M772 270 C772 330,808 350,808 388" class="edge"/>
+  <path d="M1032 270 C1032 330,844 350,844 388" class="edge"/>
+
+  <rect x="752" y="390" width="176" height="96" rx="14" class="group"/>
+  <text x="840" y="416" text-anchor="middle" class="label">G1</text>
+  <rect x="771" y="430" width="138" height="38" rx="8" class="expr"/>
+  <text x="840" y="455" text-anchor="middle" class="code">two Scan exprs</text>
+
+  <rect x="968" y="390" width="136" height="76" rx="14" fill="#fff7ed" stroke="#d97706" stroke-width="2" stroke-dasharray="7 5"/>
+  <text x="1036" y="418" text-anchor="middle" class="label">G2</text>
+  <text x="1036" y="445" text-anchor="middle" class="small">old handle</text>
+  <path d="M968 428 C938 428,934 428,928 428" class="redirect"/>
+
+  <path d="M872 236 L932 236" class="redirect"/>
+  <text x="902" y="218" text-anchor="middle" class="small">same key</text>
+  <rect x="732" y="520" width="336" height="52" rx="12" class="ok"/>
+  <text x="900" y="552" text-anchor="middle" class="label">Required next repair: merge G4 into G3</text>
+</svg>

--- a/public/blog/2026-08-08-optimizer-lesson-02/02-worklist-backlinks.svg
+++ b/public/blog/2026-08-08-optimizer-lesson-02/02-worklist-backlinks.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
+  <title id="title">Collision propagation through parent backlinks and the merge worklist</title>
+  <desc id="desc">Merging scan group G2 into G1 rewrites its direct parent Project x. That expression collides with the Project x in G3, so pair G3 G4 enters the worklist. Processing that pair rewrites Project y and discovers a second collision between G5 and G6. The worklist continues until empty.</desc>
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#334155"/></marker>
+    <style>
+      .title{font:700 28px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.label{font:700 18px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.body{font:16px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#334155}.code{font:15px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#0f172a}.small{font:14px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#475569}.node{fill:#f8fafc;stroke:#475569;stroke-width:2}.hot{fill:#fef3c7;stroke:#d97706;stroke-width:3}.done{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.edge{stroke:#475569;stroke-width:2;fill:none;marker-end:url(#arrow2)}.back{stroke:#2563eb;stroke-width:2.5;fill:none;stroke-dasharray:7 5;marker-end:url(#arrow2)}.flow{stroke:#d97706;stroke-width:3;fill:none;marker-end:url(#arrow2)}
+    </style>
+  </defs>
+  <rect width="1200" height="700" fill="#ffffff"/>
+  <text x="600" y="42" text-anchor="middle" class="title">A collision is another group merge, not the end of the first one</text>
+
+  <text x="66" y="92" class="label">Running expression graph</text>
+
+  <rect x="75" y="130" width="180" height="68" rx="12" class="node"/>
+  <text x="165" y="157" text-anchor="middle" class="label">G5</text>
+  <text x="165" y="182" text-anchor="middle" class="code">Project[y](!G3)</text>
+  <rect x="325" y="130" width="180" height="68" rx="12" class="hot"/>
+  <text x="415" y="157" text-anchor="middle" class="label">G6</text>
+  <text x="415" y="182" text-anchor="middle" class="code">Project[y](!G4)</text>
+
+  <rect x="75" y="285" width="180" height="68" rx="12" class="node"/>
+  <text x="165" y="312" text-anchor="middle" class="label">G3</text>
+  <text x="165" y="337" text-anchor="middle" class="code">Project[x](!G1)</text>
+  <rect x="325" y="285" width="180" height="68" rx="12" class="hot"/>
+  <text x="415" y="312" text-anchor="middle" class="label">G4</text>
+  <text x="415" y="337" text-anchor="middle" class="code">Project[x](!G2)</text>
+
+  <rect x="75" y="440" width="180" height="68" rx="12" class="node"/>
+  <text x="165" y="467" text-anchor="middle" class="label">G1</text>
+  <text x="165" y="492" text-anchor="middle" class="code">Scan(t1)</text>
+  <rect x="325" y="440" width="180" height="68" rx="12" class="hot"/>
+  <text x="415" y="467" text-anchor="middle" class="label">G2</text>
+  <text x="415" y="492" text-anchor="middle" class="code">Scan(alias)</text>
+
+  <path d="M165 285 L165 198" class="edge"/>
+  <path d="M415 285 L415 198" class="edge"/>
+  <path d="M165 440 L165 353" class="edge"/>
+  <path d="M415 440 L415 353" class="edge"/>
+
+  <path d="M505 474 C575 474,575 320,505 320" class="back"/>
+  <text x="545" y="392" class="small" transform="rotate(-90 545 392)">parent_exprs[G2] points to this Project</text>
+  <path d="M255 319 C290 319,290 164,255 164" class="back"/>
+  <text x="274" y="243" class="small" transform="rotate(-90 274 243)">parent_exprs[G3]</text>
+
+  <rect x="610" y="105" width="520" height="490" rx="18" fill="#f8fafc" stroke="#cbd5e1"/>
+  <text x="640" y="145" class="label">LIFO merge worklist</text>
+
+  <rect x="650" y="175" width="440" height="82" rx="14" class="hot"/>
+  <text x="675" y="205" class="label">1. Pop (G1, G2)</text>
+  <text x="675" y="232" class="body">Capture G2's backlinks, redirect G2, rewrite Project[x].</text>
+  <path d="M870 257 L870 292" class="flow"/>
+
+  <rect x="650" y="295" width="440" height="82" rx="14" class="hot"/>
+  <text x="675" y="325" class="label">2. Discover (G3, G4)</text>
+  <text x="675" y="352" class="body">The rewritten Project[x] key already belongs to G3.</text>
+  <path d="M870 377 L870 412" class="flow"/>
+
+  <rect x="650" y="415" width="440" height="82" rx="14" class="hot"/>
+  <text x="675" y="445" class="label">3. Pop (G3, G4)</text>
+  <text x="675" y="472" class="body">Rewrite Project[y], then discover collision (G5, G6).</text>
+  <path d="M870 497 L870 527" class="flow"/>
+
+  <rect x="650" y="530" width="440" height="48" rx="12" class="done"/>
+  <text x="870" y="561" text-anchor="middle" class="label">Continue until the worklist is empty</text>
+
+  <rect x="72" y="570" width="436" height="76" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="92" y="598" class="label">Backlink boundary</text>
+  <text x="92" y="623" class="body">Backlinks target each individual rewrite. The cascade may still</text>
+  <text x="92" y="644" class="body">touch much of the memo, so they do not make merging globally local.</text>
+</svg>

--- a/public/blog/2026-08-08-optimizer-lesson-02/03-stage-map.svg
+++ b/public/blog/2026-08-08-optimizer-lesson-02/03-stage-map.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">Four stages from shallow redirect to invariant-preserving memo merge</title>
+  <desc id="desc">Stage 1 redirects a group but leaves stale child IDs. Stage 2 rewrites child IDs but can create duplicate expression keys. Stage 3 processes collision-driven group merges to a fixed point. Stage 4 uses parent backlinks to target each individual rewrite while also preserving stale handles and winners.</desc>
+  <defs>
+    <marker id="arrow3" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#64748b"/></marker>
+    <style>
+      .title{font:700 28px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.num{font:700 30px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#ffffff}.label{font:700 20px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#0f172a}.body{font:16px ui-sans-serif,system-ui,-apple-system,sans-serif;fill:#334155}.code{font:15px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#0f172a}.card{fill:#f8fafc;stroke:#94a3b8;stroke-width:2}.bad{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.warn{fill:#fef3c7;stroke:#d97706;stroke-width:2}.good{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.arrow{stroke:#64748b;stroke-width:3;fill:none;marker-end:url(#arrow3)}
+    </style>
+  </defs>
+  <rect width="1200" height="760" fill="#ffffff"/>
+  <text x="600" y="44" text-anchor="middle" class="title">Each local repair exposes the next global invariant</text>
+
+  <rect x="55" y="90" width="500" height="250" rx="18" class="card"/>
+  <circle cx="102" cy="137" r="29" fill="#dc2626"/><text x="102" y="147" text-anchor="middle" class="num">1</text>
+  <text x="148" y="132" class="label">Redirect the losing group</text>
+  <text x="148" y="158" class="code">move_group(merge_into, merge_from)</text>
+  <rect x="82" y="188" width="446" height="62" rx="10" class="bad"/>
+  <text x="102" y="214" class="body">Failure symptom: stored expressions still contain the old child ID.</text>
+  <text x="102" y="237" class="body">A later insertion misses deduplication and creates a duplicate group.</text>
+  <text x="82" y="287" class="body">Missing invariant: every stored child is its canonical group.</text>
+
+  <rect x="645" y="90" width="500" height="250" rx="18" class="card"/>
+  <circle cx="692" cy="137" r="29" fill="#d97706"/><text x="692" y="147" text-anchor="middle" class="num">2</text>
+  <text x="738" y="132" class="label">Rewrite affected child IDs</text>
+  <text x="738" y="158" class="code">canonicalize_expr(old_expr)</text>
+  <rect x="672" y="188" width="446" height="62" rx="10" class="warn"/>
+  <text x="692" y="214" class="body">Failure symptom: two old keys become the same new key.</text>
+  <text x="692" y="237" class="body">Their owner groups remain separate unless the collision is merged.</text>
+  <text x="672" y="287" class="body">Missing invariant: equal expression keys imply equivalent owners.</text>
+
+  <path d="M555 215 L632 215" class="arrow"/>
+  <path d="M895 340 C895 378,895 378,895 405" class="arrow"/>
+
+  <rect x="645" y="420" width="500" height="250" rx="18" class="card"/>
+  <circle cx="692" cy="467" r="29" fill="#2563eb"/><text x="692" y="477" text-anchor="middle" class="num">3</text>
+  <text x="738" y="462" class="label">Process collisions to a fixed point</text>
+  <text x="738" y="488" class="code">while let Some(pair) = worklist.pop()</text>
+  <rect x="672" y="518" width="446" height="62" rx="10" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/>
+  <text x="692" y="544" class="body">Repair: canonicalize each pair, rewrite parents, and push newly</text>
+  <text x="692" y="567" class="body">discovered owner-group collisions until no work remains.</text>
+  <text x="672" y="617" class="body">Boundary: scanning the whole memo finds parents but repeats work.</text>
+
+  <rect x="55" y="420" width="500" height="250" rx="18" class="card"/>
+  <circle cx="102" cy="467" r="29" fill="#16a34a"/><text x="102" y="477" text-anchor="middle" class="num">4</text>
+  <text x="148" y="462" class="label">Follow parent backlinks</text>
+  <text x="148" y="488" class="code">parent_exprs[merge_from]</text>
+  <rect x="82" y="518" width="446" height="62" rx="10" class="good"/>
+  <text x="102" y="544" class="body">Repair: target expressions whose keys can change, then maintain</text>
+  <text x="102" y="567" class="body">the reverse index through every rewrite and collision.</text>
+  <text x="82" y="617" class="body">Cross-cutting state: redirects, stale handles, and cheaper winners.</text>
+
+  <path d="M645 545 L568 545" class="arrow"/>
+
+  <rect x="195" y="698" width="810" height="42" rx="12" fill="#ecfdf5" stroke="#059669" stroke-width="2"/>
+  <text x="600" y="725" text-anchor="middle" class="label">Done only when every materialized view of equivalence agrees</text>
+</svg>

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -3,8 +3,6 @@ title: "A Good Memo Table Is Hard to Build"
 pubDate: "2026-08-08T12:00:00-05:00"
 tags: ["optimizer-lesson", "optimizer", "Rust", "query optimization", "cascades"]
 description: "Group merging looks local. It is not. Four escalating failures and what they teach about memo-table design."
-socialImage: "/images/2026-08-08-optimizer-lesson-02-social.png"
-heroImage: "/images/2026-08-08-optimizer-lesson-02-banner.png"
 ---
 
 # Table of Contents
@@ -47,6 +45,8 @@ This post works through the failures one stage at a time, using the code in the 
 The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions:
 
 ```rust
+/// Illustrative — the actual crate uses `move_group` and
+/// redirect maps. See `s01_shallow_merge.rs` for the real code.
 fn merge_group(&mut self, a: GroupId, b: GroupId) {
     self.group_redirect.insert(a, b);
     // Nothing else — no expression rewriting
@@ -63,20 +63,16 @@ A redirect map makes representative lookup possible. It does not re-express stor
 
 # Stage 2: Rewriting Children Changes Identity
 
-The obvious fix is to rewrite every expression that directly references the losing group, replacing child IDs with the surviving representative. `s02_rewrite_children` shows this:
+The fix rewrites every expression that directly references the losing group.
+`s02_rewrite_children` demonstrates this. An illustrative sketch:
 
 ```rust
-fn merge_group(&mut self, a: GroupId, b: GroupId) {
-    self.group_redirect.insert(a, b);
-    for &expr_id in &self.expressions_referencing(a) {
-        self.rewrite_children(expr_id, |child| {
-            if child == a { b } else { child }
-        });
-    }
-}
+/// Illustrative — see `s02_rewrite_children.rs` for the real
+/// implementation which traverses expressions by group and
+/// replaces children using the redirect map.
 ```
 
-This fixes the shallow case. But the tests `expression_collisions_can_merge_groups` and `merged_groups_collapse_to_one` reveal a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
+But the tests `rewriting_children_can_create_duplicate_expressions` and `merged_groups_collapse_to_one` reveal a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 
 > **Congruence closure:** If `key(e1) == key(e2)`, the groups containing `e1` and `e2` must be merged.
 
@@ -109,7 +105,7 @@ Other query optimizers have encountered this problem:
 
 The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not specify how to find affected parents, repair hash-table keys, detect cascading collisions, or handle stale winners and state. Those details become the implementation.
 
-In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass runs DPhyp separately for each join group, with DP entries keyed by relation subsets.
+In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass recurses per group and memoizes by `GroupId` to avoid repeated DP work on the same relation subset.
 
 # What We Learned
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -45,14 +45,14 @@ The crate's `s01_shallow_merge` module shows what happens with the simplest merg
 
 ```rust
 An illustrative sketch of the shallow merge (the real code uses
-`merge_group_shallow`, returns `GroupId`, and merges `from` into `to`):
+`merge_group_shallow(merge_into, merge_from)` and redirects
+`merge_from -> merge_into`):
 
 ```rust
-fn merge_group_shallow(&mut self, from: GroupId, to: GroupId) -> GroupId {
-    self.group_redirect.insert(from, to);
-    to
+fn merge_group_shallow(&mut self, merge_into: GroupId, merge_from: GroupId) -> GroupId {
+    self.group_redirect.insert(merge_from, merge_into);
+    merge_into
 }
-```
 ```
 
 The test `shallow_merge_leaves_stale_children` demonstrates the failure. Two expressions are created in different groups. After merging the groups, a new expression that should be structurally equivalent to an existing one ends up in a different group because the existing expression still references stale child IDs. The memo now has two groups representing expressions that should have been deduplicated.
@@ -66,7 +66,7 @@ A redirect map makes representative lookup possible. It does not re-express stor
 # Stage 2: Rewriting Children Changes Identity
 
 The fix rewrites every expression that directly references the losing group.
-`s02_rewrite_children` demonstrates this.
+`s02_rewrite_children` demonstrates this. `merge_group_rewrite_only` scans every stored expression, selects those whose children contain `merge_from`, and rewrites those child IDs to `merge_to`.
 
 But the test `rewriting_children_can_create_duplicate_expressions` reveals a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 
@@ -78,7 +78,7 @@ After rewriting, the code must check whether any rewritten expression now collid
 
 After a merge rewrites children and produces new collisions, those new merges may rewrite more children and produce more collisions. The process repeats until no new merges appear: a fixed-point computation.
 
-`s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix requires either a worklist of pending merges or recursive merging that continues until no new pairs are found.
+`s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix resolves collisions until no new merges appear.
 
 The published code uses an explicit worklist that canonicalizes each discovered pair when processed and continues until the worklist is empty. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning every expression for each individual merge, while a cascade can still touch a large part of the memo.
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -1,0 +1,230 @@
+---
+title: "Memo Mayhem: #2 Lessons Learned from Building an Optimizer"
+pubDate: "2026-08-08T12:00:00-05:00"
+tags: ["optimizer-lesson", "optimizer", "Rust", "query optimization", "cascades"]
+description: "Group merging looks local. It is not. Four escalating failures and what they teach about memo-table design."
+socialImage: "/images/2026-08-08-optimizer-lesson-02-social.png"
+heroImage: "/images/2026-08-08-optimizer-lesson-02-banner.png"
+---
+
+import { Image } from "astro:assets";
+
+# Table of Contents
+
+---
+
+# Introduction
+
+<div style={{"border": "1px solid", "padding": "0.5em"}}>
+
+This is the second part of my blog post series, "Lessons Learned from Building a Query Optimizer". In [Lesson 1](/blog/2025-02-06-optimizer-lesson-01/), we built a generic plan representation with group IDs and left `merge_group` as an unimplemented stub. Today we finish that function. The result is not a single patch. It is four escalating failures, each exposing a structural truth about memo tables that I did not understand until the code forced me to.
+
+You can find the code for this post at [skyzh/optimizer-lessons](https://github.com/skyzh/optimizer-lessons), branch `skyzh/lesson-2-memo-table`.
+
+Let me be clear about scope. Group merging is a narrow problem: when two group IDs become equivalent, reconcile every piece of state that depends on them. This post is about the _structure_ of that reconciliation, not about cost models, cardinality estimation, or the search algorithm. Those matter, but they sit on top of a memo that must first be correct.
+
+</div>
+
+# The Setup
+
+In Lesson 1, we introduced a memo table indexed by group ID. Each expression is stored under a group, and the optimizer's job is to explore equivalent expressions within a group. The API looked like this:
+
+```rust
+/// Find or create a group for the given expression.
+fn find_or_insert_group(expr: Expr) -> GroupId;
+
+/// Merge two groups, making them equivalent.
+fn merge_group(a: GroupId, b: GroupId);
+```
+
+`find_or_insert_group` was straightforward. `merge_group` was not.
+
+The problem is that a group does not just contain expressions. It materializes an equivalence relation across many data structures: stored expressions that reference child group IDs, hash tables that let us find a group by its expression key, reverse indexes that point from children back to their parents, and optimizer state like winners and costs. When two groups become equivalent, every index that saw them as distinct must be reconciled.
+
+This post works through the failures one at a time, using the test cases in `lesson-2`. Each test is a minimal program that reveals one missing invariant.
+
+# Failure 1: The Shallow Merge
+
+Let us start with the simplest thing that could work. `merge_group(a, b)` sets one group's representative to the other using union-find:
+
+```rust
+fn merge_group(&mut self, a: GroupId, b: GroupId) {
+    let root_a = self.uf.find(a);
+    let root_b = self.uf.find(b);
+    if root_a == root_b { return; }
+    self.uf.union(root_a, root_b); // root_a now points to root_b
+}
+```
+
+Union-find makes representative lookup cheap. If someone asks for the group of an expression whose group was merged, `find` returns the surviving representative. But union-find does not rewrite the stored expressions. A `Join { left: a, right: c }` still contains `a` as a literal child ID. When the optimizer later reads that child and calls `find(a)`, it gets `b`, so the plan is still structurally reachable. What breaks?
+
+The test `s01_shallow_merge` answers this. Create two distinct expressions and merge their groups:
+
+```rust
+// Expression 1: Join(Scan(t1), Scan(t2))
+// Expression 2: Scan(t1) — a different group
+let join_id = memo.find_or_insert_group(join_expr);
+let scan_id = memo.find_or_insert_group(scan_expr);
+
+// Merge: join_id and scan_id are now the same group
+memo.merge_group(join_id, scan_id);
+
+// Later: insert another Join(Scan(t1), Scan(t2))
+// This expression already exists in the merged group.
+// But find_or_insert_group can't find it because
+// the stored Join still references join_id directly,
+// not the surviving representative.
+```
+
+The failure is in the hash key. `find_or_insert_group` hashes the expression including its raw child IDs. After the merge, the old expression at `join_id` still carries the original child IDs. A new expression with the same structure but resolved to the post-merge representative produces a different hash key, so the lookup misses. The memo now contains two copies of the same expression in the same equivalence group.
+
+The invariant we broke is:
+
+> **Key invariance:** If two expressions are structurally identical after resolving their child groups to canonical representatives, they must share a group.
+
+Union-find gives us a `find` operation. We did not use it when computing expression keys.
+
+# Failure 2: Rewriting Children Changes Identity
+
+The fix seems obvious: when we merge groups, rewrite every stored expression's children to use the canonical representative.
+
+```rust
+fn merge_group(&mut self, a: GroupId, b: GroupId) {
+    let root = self.uf.union(a, b);
+    // Rewrite all stored expressions to use canonical child IDs
+    for expr in self.expressions_of(root_a).chain(self.expressions_of(root_b)) {
+        expr.children_mut().for_each(|c| *c = self.uf.find(*c));
+    }
+}
+```
+
+This works for the shallow case. But it introduces a new problem, demonstrated in `s02_rewrite_children`.
+
+Two expressions that were different before the merge can become textually identical after rewriting:
+
+```rust
+// Group 1: Join(Scan(t1), Scan(t2))
+// Group 2: Join(Scan(t1), Scan(t3))
+// Group 3: Scan(t2) — merged with Group 4
+// Group 4: Scan(t3)
+
+memo.merge_group(group3, group4); // t2 and t3 are now the same group
+// After rewriting:
+// Group 1: Join(Scan(t1), Scan(tX))  where X = find(t2) = find(t3)
+// Group 2: Join(Scan(t1), Scan(tX))
+// These are identical!
+```
+
+Two previously distinct expressions just became identical. That means their groups are now equivalent — but we did not merge them. We broke a deeper invariant:
+
+> **Congruence closure:** If `key(e1) == key(e2)`, then `find(owner(e1)) == find(owner(e2))`.
+
+Rewriting child IDs inside an expression changes its key. If the new key collides with another expression, the owning groups must be merged. But finding those collisions means checking every expression whose key might have changed — which, after a merge, could be far more than the two groups we started with.
+
+# Failure 3: Cascading Merges
+
+After a merge rewrites children, we must check for new duplicate expressions and merge their groups. Those merges may rewrite more children, producing more duplicates. The process continues until no new collisions appear: a fixed-point computation.
+
+The test `s03_cascading_merge` constructs a chain that triggers exactly this:
+
+```rust
+// Create a chain where each merge creates one new collision
+// Group A: expr X
+// Group B: expr Y (references A)
+// Group C: expr Z (references B)
+// Merge groups so that X and Y become equivalent,
+// then the rewritten Z collides with something else...
+```
+
+The fix requires a worklist algorithm:
+
+```rust
+fn merge_group(&mut self, a: GroupId, b: GroupId) {
+    let mut worklist = vec![(a, b)];
+    while let Some((g1, g2)) = worklist.pop() {
+        let root = self.uf.union(g1, g2);
+        // Rewrite children in all affected expressions
+        let affected = self.expressions_referencing(g1)
+            .chain(self.expressions_referencing(g2));
+        for expr in affected {
+            let old_key = self.key_of(expr);
+            expr.children_mut().for_each(|c| *c = self.uf.find(*c));
+            let new_key = self.key_of(expr);
+            if old_key != new_key {
+                // This expression's key changed. Check for collision.
+                if let Some(other) = self.hash_table.get(&new_key) {
+                    let other_owner = self.uf.find(other.owner);
+                    if other_owner != root {
+                        worklist.push((root, other_owner));
+                    }
+                }
+                // Update hash table entry
+                self.hash_table.remove(&old_key);
+                self.hash_table.insert(new_key, expr);
+            }
+        }
+    }
+}
+```
+
+This is the heart of the problem. A local operation triggers global reconciliation, and the scope of that reconciliation is unbounded in the worst case: one merge can cascade through the entire memo. The union-find makes representative lookup fast, but it did not solve the hash-key repair or the fixed-point search.
+
+# Failure 4: Finding Parents Efficiently
+
+The worklist algorithm above has a hidden cost: `expressions_referencing(g)`. How do we find all expressions whose children include a particular group? Scanning the entire memo is correct but quadratic.
+
+The answer is to maintain a reverse index from each group to the expressions that reference it — parent backlinks. This is what `s04_parent_backlinks` tests:
+
+```rust
+struct Memo {
+    // ... existing fields ...
+    /// For each group, the set of expression IDs whose children include this group.
+    parent_links: HashMap<GroupId, HashSet<ExprId>>,
+}
+```
+
+When an expression is inserted, we add its ID to the parent-link set of each child group. When a group is merged, the surviving group inherits the parent-link sets of both inputs. The worklist then iterates over exactly the affected expressions — linear in the number of direct parents, not the size of the memo.
+
+But parent backlinks are themselves a new invariant. They must stay consistent with the stored expressions at all times: a backlink must exist if and only if a child reference exists. And they do not solve the remaining problems: when a winner or cost is attached to a merged group, which value survives? When a task is scheduled against a group that no longer exists, does it run against the representative? What about statistics, property envelopes, or rule application state?
+
+These are the questions the `merge_state_tests` suite begins to probe, and they are what separates our demo from a production memo. The lesson is not that backlinks make merging cheap. It is that every index that materializes the same equivalence relation adds a reconciliation obligation, and the cross-product of those obligations grows with each new piece of optimizer state.
+
+# The Bigger Picture
+
+I was not the first person to encounter this. The Columbia query optimizer — a public Cascades-derived system — has a `MergeGroups` method. In its default build, that method is stubbed with an `assert(false)`. It was never fully implemented.
+
+This is not evidence that the original Cascades implementation was buggy. It is evidence that the Cascades _paper_ abstracts group merging away. The paper tells you that when two groups are found to be equivalent, you merge them. It tells you to merge pattern memories and re-check rules. It does not tell you how to find the parents that need rewriting, how to detect cascading collisions, how to repair hash-table keys, or how to handle stale winners, tasks, and statistics. Those details become the implementation, and the implementation is where the difficulty lives.
+
+Modern query optimizers take different approaches to this problem:
+
+- **Apache Calcite** (Volcano) eagerly rewrites with parent backlinks and a recursive set merge that repairs costs and metadata.
+- **Doris Nereids** has the most complete merge in open-source Cascades: it merges costs, properties, rule masks, winners, statistics, and DPhyp state explicitly.
+- **Greenplum ORCA** marks duplicates during search and performs a global rehash at a quiescent phase boundary rather than merging eagerly.
+- **CockroachDB** constrains insertion so that distinct semantic groups never collide, avoiding the general merge problem.
+- **egg** rebuilds parent indexes from scratch during each merge, giving a clean structural algorithm at the cost of recomputation. Application-specific state (e.g., analysis data) still needs its own join policy.
+
+In my own optimizer work, the 2025 version of optd used union-find with a global write lock and tried to merge eagerly. Finding all the stale edges — tasks, required properties, optimization state — proved brittle. The current optd codebase avoids a general memo entirely: it uses append-only expression handles and runs DPhyp per relation subset, which sidesteps the need for group equivalence at the memo level.
+
+# What We Learned
+
+Group merging in a memo table is not a vector append. It is a structural reconciliation that touches stored expressions, hash keys, parent links, winners, costs, tasks, statistics, and application state. Four specific invariants fell out of the escalating test cases:
+
+1. **Expression-key invariance:** after a merge, two structurally identical expressions (with children resolved to canonical representatives) must be in the same group. Union-find alone does not guarantee this — you must rewrite stored child IDs and re-key the hash table.
+
+2. **Congruence closure:** rewriting children can make previously distinct expressions identical, producing new group equivalences. Detecting them requires checking for hash-key collisions after every rewrite, not just in the originally merged groups.
+
+3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point worklist. The worst-case scope is the entire memo.
+
+4. **Parent indexing:** finding the expressions affected by a merge requires reverse indexes from groups to their parent expressions. These indexes are themselves a new invariant to maintain.
+
+The implementation is in the `lesson-2` crate under four test stages: `s01_shallow_merge`, `s02_rewrite_children`, `s03_cascading_merge`, and `s04_parent_backlinks`, plus a `merge_state_tests` module that begins to probe the winner/task/statistics surface. Run them:
+
+```bash
+cargo test -p lesson-2
+```
+
+If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the test cases in order. The structural lessons apply regardless of whether you use union-find, a worklist, parent backlinks, or a specialized data structure. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.
+
+---
+
+*Thanks to the optimizer-lessons team for code review and test design. The Lesson 2 implementation is by Forge; this post was drafted by Sentinel and reviewed by the editorial lane.*

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -28,12 +28,11 @@ You can find the code for this post at [skyzh/optimizer-lessons](https://github.
 In Lesson 1, we introduced a memo table indexed by group ID. Each expression is stored under a group. The optimizer's job is to explore equivalent expressions within a group. Two operations matter here: `add_expr` (which Lesson 1 implemented) and `merge_group` (which it left as a stub).
 
 ```rust
-/// Insert an expression into the memo, returning its group ID.
-fn add_expr(&mut self, expr: Expr) -> GroupId;
+/// Insert an expression into the memo.
+fn add_expr(&mut self, expr: MemoExpr) -> (GroupId, ExprId);
 
 /// Declare that two groups are equivalent.
-/// Lesson 2 implements this.
-fn merge_group(&mut self, a: GroupId, b: GroupId);
+fn merge_group(&mut self, a: GroupId, b: GroupId) -> GroupId;
 ```
 
 The problem is that a group does not just contain expressions. The memo and its indexes materialize an equivalence relation across many data structures: stored expressions that reference child group IDs, redirect maps that point from merged groups to their representatives, hash tables that locate a group by its expression key, and state like winners and costs. When two groups become equivalent, every index that saw them as distinct must be reconciled.
@@ -45,12 +44,15 @@ This post works through the failures one stage at a time, using the code in the 
 The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions:
 
 ```rust
-/// Illustrative — the actual crate uses `move_group` and
-/// redirect maps. See `s01_shallow_merge.rs` for the real code.
-fn merge_group(&mut self, a: GroupId, b: GroupId) {
-    self.group_redirect.insert(a, b);
-    // Nothing else — no expression rewriting
+An illustrative sketch of the shallow merge (the real code uses
+`merge_group_shallow`, returns `GroupId`, and merges `from` into `to`):
+
+```rust
+fn merge_group_shallow(&mut self, from: GroupId, to: GroupId) -> GroupId {
+    self.group_redirect.insert(from, to);
+    to
 }
+```
 ```
 
 The test `shallow_merge_leaves_stale_children` demonstrates the failure. Two expressions are created in different groups. After merging the groups, a new expression that should be structurally equivalent to an existing one ends up in a different group because the existing expression still references stale child IDs. The memo now has two groups representing expressions that should have been deduplicated.
@@ -84,7 +86,7 @@ After a merge rewrites children and produces new collisions, those new merges ma
 
 `s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix requires either a worklist of pending merges or recursive merging that continues until no new pairs are found.
 
-The mechanism is not a single algorithm. The published code uses an explicit worklist that canonicalizes each discovered pair when processed and continues until the queue is empty. A union-find with a hash-key repair loop is an alternative. The invariant is the same: after a fixed point, no two expressions with the same key belong to different groups. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning the full expression set, but they do not make the overall merge local or linear.
+The published code uses an explicit worklist that canonicalizes each discovered pair when processed and continues until the worklist is empty. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning every expression for each individual merge, while a cascade can still touch a large part of the memo.
 
 # Stage 4: Parent Backlinks
 
@@ -105,7 +107,7 @@ Other query optimizers have encountered this problem:
 
 The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not specify how to find affected parents, repair hash-table keys, detect cascading collisions, or handle stale winners and state. Those details become the implementation.
 
-In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass recurses per group and memoizes by `GroupId` to avoid repeated DP work on the same relation subset.
+In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass builds a hypergraph per join-group root and uses a DP table keyed by `NodeSet`; this is a different design from the older per-`GroupId` memoization path.
 
 # What We Learned
 
@@ -115,7 +117,7 @@ Group merging in a memo table is a structural reconciliation that touches stored
 
 2. **Congruence closure:** rewriting children can make previously distinct expressions identical, producing new group equivalences that must also be merged.
 
-3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point traversal. The mechanism (worklist, recursive merge, or union-find with hash repair) must converge.
+3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point traversal. The published implementation uses an explicit canonicalizing fixed-point worklist; union-find with hash-key repair is an alternative design.
 
 4. **Parent indexing:** finding affected expressions without scanning the entire memo requires reverse indexes from groups to their parent expressions. These indexes are themselves a new invariant.
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -84,7 +84,7 @@ After a merge rewrites children and produces new collisions, those new merges ma
 
 `s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix requires either a worklist of pending merges or recursive merging that continues until no new pairs are found.
 
-The mechanism is not a single algorithm. The published code uses a `pending_group_merges` vector and a recursive call that drains it. A union-find with a hash-key repair loop is an alternative. The invariant is the same: after a fixed point, no two expressions with the same key belong to different groups. Finding all affected expressions requires tracking which expressions reference each group — one full scan per merge is linear in memo size, but repeated scans across a cascade can become quadratic.
+The mechanism is not a single algorithm. The published code uses an explicit worklist that canonicalizes each discovered pair when processed and continues until the queue is empty. A union-find with a hash-key repair loop is an alternative. The invariant is the same: after a fixed point, no two expressions with the same key belong to different groups. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning the full expression set, but they do not make the overall merge local or linear.
 
 # Stage 4: Parent Backlinks
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -7,8 +7,6 @@ socialImage: "/images/2026-08-08-optimizer-lesson-02-social.png"
 heroImage: "/images/2026-08-08-optimizer-lesson-02-banner.png"
 ---
 
-import { Image } from "astro:assets";
-
 # Table of Contents
 
 ---
@@ -17,210 +15,118 @@ import { Image } from "astro:assets";
 
 <div style={{"border": "1px solid", "padding": "0.5em"}}>
 
-This is the second part of my blog post series, "Lessons Learned from Building a Query Optimizer". In [Lesson 1](/blog/2025-02-06-optimizer-lesson-01/), we built a generic plan representation with group IDs and left `merge_group` as an unimplemented stub. Today we finish that function. The result is not a single patch. It is four escalating failures, each exposing a structural truth about memo tables that I did not understand until the code forced me to.
+This is the second part of my blog post series, "Lessons Learned from Building a Query Optimizer". In [Lesson 1](/blog/2025-02-06-optimizer-lesson-01/), we built a generic plan representation with group IDs and left `merge_group` as an unimplemented stub. Today we finish that function.
+
+Merging two memo groups means choosing one representative and repairing every expression and index that refers to either group. The result is not a single patch. It is four escalating stages, each exposing a structural truth about memo tables.
+
+Group merging is a narrow problem: when two group IDs become equivalent, reconcile every piece of state that depends on them. This post is about the _structure_ of that reconciliation, not about cost models, cardinality estimation, or the search algorithm. Those matter, but they sit on top of a memo that must first be correct.
 
 You can find the code for this post at [skyzh/optimizer-lessons](https://github.com/skyzh/optimizer-lessons), branch `skyzh/lesson-2-memo-table`.
-
-Let me be clear about scope. Group merging is a narrow problem: when two group IDs become equivalent, reconcile every piece of state that depends on them. This post is about the _structure_ of that reconciliation, not about cost models, cardinality estimation, or the search algorithm. Those matter, but they sit on top of a memo that must first be correct.
 
 </div>
 
 # The Setup
 
-In Lesson 1, we introduced a memo table indexed by group ID. Each expression is stored under a group, and the optimizer's job is to explore equivalent expressions within a group. The API looked like this:
+In Lesson 1, we introduced a memo table indexed by group ID. Each expression is stored under a group. The optimizer's job is to explore equivalent expressions within a group. Two operations matter here: `add_expr` (which Lesson 1 implemented) and `merge_group` (which it left as a stub).
 
 ```rust
-/// Find or create a group for the given expression.
-fn find_or_insert_group(expr: Expr) -> GroupId;
+/// Insert an expression into the memo, returning its group ID.
+fn add_expr(&mut self, expr: Expr) -> GroupId;
 
-/// Merge two groups, making them equivalent.
-fn merge_group(a: GroupId, b: GroupId);
+/// Declare that two groups are equivalent.
+/// Lesson 2 implements this.
+fn merge_group(&mut self, a: GroupId, b: GroupId);
 ```
 
-`find_or_insert_group` was straightforward. `merge_group` was not.
+The problem is that a group does not just contain expressions. The memo and its indexes materialize an equivalence relation across many data structures: stored expressions that reference child group IDs, redirect maps that point from merged groups to their representatives, hash tables that locate a group by its expression key, and state like winners and costs. When two groups become equivalent, every index that saw them as distinct must be reconciled.
 
-The problem is that a group does not just contain expressions. It materializes an equivalence relation across many data structures: stored expressions that reference child group IDs, hash tables that let us find a group by its expression key, reverse indexes that point from children back to their parents, and optimizer state like winners and costs. When two groups become equivalent, every index that saw them as distinct must be reconciled.
+This post works through the failures one stage at a time, using the code in the `optimizer-blog-lesson-2` crate. Each stage contains focused tests for one missing invariant.
 
-This post works through the failures one at a time, using the test cases in `lesson-2`. Each test is a minimal program that reveals one missing invariant.
+# Stage 1: The Shallow Merge
 
-# Failure 1: The Shallow Merge
-
-Let us start with the simplest thing that could work. `merge_group(a, b)` sets one group's representative to the other using union-find:
+The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions:
 
 ```rust
 fn merge_group(&mut self, a: GroupId, b: GroupId) {
-    let root_a = self.uf.find(a);
-    let root_b = self.uf.find(b);
-    if root_a == root_b { return; }
-    self.uf.union(root_a, root_b); // root_a now points to root_b
+    self.group_redirect.insert(a, b);
+    // Nothing else — no expression rewriting
 }
 ```
 
-Union-find makes representative lookup cheap. If someone asks for the group of an expression whose group was merged, `find` returns the surviving representative. But union-find does not rewrite the stored expressions. A `Join { left: a, right: c }` still contains `a` as a literal child ID. When the optimizer later reads that child and calls `find(a)`, it gets `b`, so the plan is still structurally reachable. What breaks?
+The test `shallow_merge_leaves_stale_children` demonstrates the failure. Two expressions are created in different groups. After merging the groups, a new expression that should be structurally equivalent to an existing one ends up in a different group because the existing expression still references stale child IDs. The memo now has two groups representing expressions that should have been deduplicated.
 
-The test `s01_shallow_merge` answers this. Create two distinct expressions and merge their groups:
-
-```rust
-// Expression 1: Join(Scan(t1), Scan(t2))
-// Expression 2: Scan(t1) — a different group
-let join_id = memo.find_or_insert_group(join_expr);
-let scan_id = memo.find_or_insert_group(scan_expr);
-
-// Merge: join_id and scan_id are now the same group
-memo.merge_group(join_id, scan_id);
-
-// Later: insert another Join(Scan(t1), Scan(t2))
-// This expression already exists in the merged group.
-// But find_or_insert_group can't find it because
-// the stored Join still references join_id directly,
-// not the surviving representative.
-```
-
-The failure is in the hash key. `find_or_insert_group` hashes the expression including its raw child IDs. After the merge, the old expression at `join_id` still carries the original child IDs. A new expression with the same structure but resolved to the post-merge representative produces a different hash key, so the lookup misses. The memo now contains two copies of the same expression in the same equivalence group.
-
-The invariant we broke is:
+The invariant we broke:
 
 > **Key invariance:** If two expressions are structurally identical after resolving their child groups to canonical representatives, they must share a group.
 
-Union-find gives us a `find` operation. We did not use it when computing expression keys.
+A redirect map makes representative lookup possible. It does not re-express stored child IDs. After the merge, the old expression still carries the original child IDs, so a new expression with the same structure but resolved to the post-merge representatives produces a different key. The deduplication fails.
 
-# Failure 2: Rewriting Children Changes Identity
+# Stage 2: Rewriting Children Changes Identity
 
-The fix seems obvious: when we merge groups, rewrite every stored expression's children to use the canonical representative.
+The obvious fix is to rewrite every expression that directly references the losing group, replacing child IDs with the surviving representative. `s02_rewrite_children` shows this:
 
 ```rust
 fn merge_group(&mut self, a: GroupId, b: GroupId) {
-    let root = self.uf.union(a, b);
-    // Rewrite all stored expressions to use canonical child IDs
-    for expr in self.expressions_of(root_a).chain(self.expressions_of(root_b)) {
-        expr.children_mut().for_each(|c| *c = self.uf.find(*c));
+    self.group_redirect.insert(a, b);
+    for &expr_id in &self.expressions_referencing(a) {
+        self.rewrite_children(expr_id, |child| {
+            if child == a { b } else { child }
+        });
     }
 }
 ```
 
-This works for the shallow case. But it introduces a new problem, demonstrated in `s02_rewrite_children`.
+This fixes the shallow case. But the tests `expression_collisions_can_merge_groups` and `merged_groups_collapse_to_one` reveal a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 
-Two expressions that were different before the merge can become textually identical after rewriting:
+> **Congruence closure:** If `key(e1) == key(e2)`, the groups containing `e1` and `e2` must be merged.
 
-```rust
-// Group 1: Join(Scan(t1), Scan(t2))
-// Group 2: Join(Scan(t1), Scan(t3))
-// Group 3: Scan(t2) — merged with Group 4
-// Group 4: Scan(t3)
+After rewriting, the code must check whether any rewritten expression now collides with an existing key and, if so, add that pair to the pending merges.
 
-memo.merge_group(group3, group4); // t2 and t3 are now the same group
-// After rewriting:
-// Group 1: Join(Scan(t1), Scan(tX))  where X = find(t2) = find(t3)
-// Group 2: Join(Scan(t1), Scan(tX))
-// These are identical!
-```
+# Stage 3: Cascading Merges
 
-Two previously distinct expressions just became identical. That means their groups are now equivalent — but we did not merge them. We broke a deeper invariant:
+After a merge rewrites children and produces new collisions, those new merges may rewrite more children and produce more collisions. The process repeats until no new merges appear: a fixed-point computation.
 
-> **Congruence closure:** If `key(e1) == key(e2)`, then `find(owner(e1)) == find(owner(e2))`.
+`s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix requires either a worklist of pending merges or recursive merging that continues until no new pairs are found.
 
-Rewriting child IDs inside an expression changes its key. If the new key collides with another expression, the owning groups must be merged. But finding those collisions means checking every expression whose key might have changed — which, after a merge, could be far more than the two groups we started with.
+The mechanism is not a single algorithm. The published code uses a `pending_group_merges` vector and a recursive call that drains it. A union-find with a hash-key repair loop is an alternative. The invariant is the same: after a fixed point, no two expressions with the same key belong to different groups. Finding all affected expressions requires tracking which expressions reference each group — one full scan per merge is linear in memo size, but repeated scans across a cascade can become quadratic.
 
-# Failure 3: Cascading Merges
+# Stage 4: Parent Backlinks
 
-After a merge rewrites children, we must check for new duplicate expressions and merge their groups. Those merges may rewrite more children, producing more duplicates. The process continues until no new collisions appear: a fixed-point computation.
+To avoid scanning the entire memo for affected expressions, the code maintains a reverse index: `parent_exprs: HashMap<GroupId, BTreeSet<ExprId>>`. When an expression is inserted, its ID is added to the parent set of every child group. When a merge occurs, only the expressions that directly reference the losing group need rewriting; the surviving group inherits the losing group's parent set.
 
-The test `s03_cascading_merge` constructs a chain that triggers exactly this:
-
-```rust
-// Create a chain where each merge creates one new collision
-// Group A: expr X
-// Group B: expr Y (references A)
-// Group C: expr Z (references B)
-// Merge groups so that X and Y become equivalent,
-// then the rewritten Z collides with something else...
-```
-
-The fix requires a worklist algorithm:
-
-```rust
-fn merge_group(&mut self, a: GroupId, b: GroupId) {
-    let mut worklist = vec![(a, b)];
-    while let Some((g1, g2)) = worklist.pop() {
-        let root = self.uf.union(g1, g2);
-        // Rewrite children in all affected expressions
-        let affected = self.expressions_referencing(g1)
-            .chain(self.expressions_referencing(g2));
-        for expr in affected {
-            let old_key = self.key_of(expr);
-            expr.children_mut().for_each(|c| *c = self.uf.find(*c));
-            let new_key = self.key_of(expr);
-            if old_key != new_key {
-                // This expression's key changed. Check for collision.
-                if let Some(other) = self.hash_table.get(&new_key) {
-                    let other_owner = self.uf.find(other.owner);
-                    if other_owner != root {
-                        worklist.push((root, other_owner));
-                    }
-                }
-                // Update hash table entry
-                self.hash_table.remove(&old_key);
-                self.hash_table.insert(new_key, expr);
-            }
-        }
-    }
-}
-```
-
-This is the heart of the problem. A local operation triggers global reconciliation, and the scope of that reconciliation is unbounded in the worst case: one merge can cascade through the entire memo. The union-find makes representative lookup fast, but it did not solve the hash-key repair or the fixed-point search.
-
-# Failure 4: Finding Parents Efficiently
-
-The worklist algorithm above has a hidden cost: `expressions_referencing(g)`. How do we find all expressions whose children include a particular group? Scanning the entire memo is correct but quadratic.
-
-The answer is to maintain a reverse index from each group to the expressions that reference it — parent backlinks. This is what `s04_parent_backlinks` tests:
-
-```rust
-struct Memo {
-    // ... existing fields ...
-    /// For each group, the set of expression IDs whose children include this group.
-    parent_links: HashMap<GroupId, HashSet<ExprId>>,
-}
-```
-
-When an expression is inserted, we add its ID to the parent-link set of each child group. When a group is merged, the surviving group inherits the parent-link sets of both inputs. The worklist then iterates over exactly the affected expressions — linear in the number of direct parents, not the size of the memo.
-
-But parent backlinks are themselves a new invariant. They must stay consistent with the stored expressions at all times: a backlink must exist if and only if a child reference exists. And they do not solve the remaining problems: when a winner or cost is attached to a merged group, which value survives? When a task is scheduled against a group that no longer exists, does it run against the representative? What about statistics, property envelopes, or rule application state?
-
-These are the questions the `merge_state_tests` suite begins to probe, and they are what separates our demo from a production memo. The lesson is not that backlinks make merging cheap. It is that every index that materializes the same equivalence relation adds a reconciliation obligation, and the cross-product of those obligations grows with each new piece of optimizer state.
+`s04_parent_backlinks` tests this mechanism. The backlinks make rewriting targeted, but they are themselves a new invariant to maintain. And they do not solve the remaining problems: the `merge_state_tests` module probes stale group and expression handles plus winner selection. Tasks, statistics, property-envelope state, and rule-application state are not modeled. Each new state field added to the memo adds another merge policy to define.
 
 # The Bigger Picture
 
-I was not the first person to encounter this. The Columbia query optimizer — a public Cascades-derived system — has a `MergeGroups` method. In its default build, that method is stubbed with an `assert(false)`. It was never fully implemented.
+Other query optimizers have encountered this problem:
 
-This is not evidence that the original Cascades implementation was buggy. It is evidence that the Cascades _paper_ abstracts group merging away. The paper tells you that when two groups are found to be equivalent, you merge them. It tells you to merge pattern memories and re-check rules. It does not tell you how to find the parents that need rewriting, how to detect cascading collisions, how to repair hash-table keys, or how to handle stale winners, tasks, and statistics. Those details become the implementation, and the implementation is where the difficulty lives.
+- The public **Columbia** source does not implement `MergeGroups` under its `UNIQ` configuration.
+- **Apache Calcite** eagerly rewrites with parent backlinks and merges costs and metadata during a recursive set merge.
+- **Doris Nereids** merges costs, properties, rule masks, winners, statistics, and DPhyp state during group consolidation.
+- **Greenplum ORCA** marks duplicates during search and performs a global rehash at a quiescent phase boundary.
+- **CockroachDB** interns immutable expressions and adds explored alternatives to an explicit target group, so it exposes no general group-merge operation.
+- **egg** tracks parent e-nodes, queues affected parents on union, restores congruence lazily in `rebuild`, and merges analysis data under a separate policy.
 
-Modern query optimizers take different approaches to this problem:
+The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not specify how to find affected parents, repair hash-table keys, detect cascading collisions, or handle stale winners and state. Those details become the implementation.
 
-- **Apache Calcite** (Volcano) eagerly rewrites with parent backlinks and a recursive set merge that repairs costs and metadata.
-- **Doris Nereids** has the most complete merge in open-source Cascades: it merges costs, properties, rule masks, winners, statistics, and DPhyp state explicitly.
-- **Greenplum ORCA** marks duplicates during search and performs a global rehash at a quiescent phase boundary rather than merging eagerly.
-- **CockroachDB** constrains insertion so that distinct semantic groups never collide, avoiding the general merge problem.
-- **egg** rebuilds parent indexes from scratch during each merge, giving a clean structural algorithm at the cost of recomputation. Application-specific state (e.g., analysis data) still needs its own join policy.
-
-In my own optimizer work, the 2025 version of optd used union-find with a global write lock and tried to merge eagerly. Finding all the stale edges — tasks, required properties, optimization state — proved brittle. The current optd codebase avoids a general memo entirely: it uses append-only expression handles and runs DPhyp per relation subset, which sidesteps the need for group equivalence at the memo level.
+In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass runs DPhyp separately for each join group, with DP entries keyed by relation subsets.
 
 # What We Learned
 
-Group merging in a memo table is not a vector append. It is a structural reconciliation that touches stored expressions, hash keys, parent links, winners, costs, tasks, statistics, and application state. Four specific invariants fell out of the escalating test cases:
+Group merging in a memo table is a structural reconciliation that touches stored expressions, redirects, hash keys, parent indexes, and winners. Four invariants fell out of the escalating stages:
 
-1. **Expression-key invariance:** after a merge, two structurally identical expressions (with children resolved to canonical representatives) must be in the same group. Union-find alone does not guarantee this — you must rewrite stored child IDs and re-key the hash table.
+1. **Expression-key invariance:** after a merge, structurally identical expressions (with children resolved to representatives) must be in the same group. A redirect map alone does not guarantee this.
 
-2. **Congruence closure:** rewriting children can make previously distinct expressions identical, producing new group equivalences. Detecting them requires checking for hash-key collisions after every rewrite, not just in the originally merged groups.
+2. **Congruence closure:** rewriting children can make previously distinct expressions identical, producing new group equivalences that must also be merged.
 
-3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point worklist. The worst-case scope is the entire memo.
+3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point traversal. The mechanism (worklist, recursive merge, or union-find with hash repair) must converge.
 
-4. **Parent indexing:** finding the expressions affected by a merge requires reverse indexes from groups to their parent expressions. These indexes are themselves a new invariant to maintain.
+4. **Parent indexing:** finding affected expressions without scanning the entire memo requires reverse indexes from groups to their parent expressions. These indexes are themselves a new invariant.
 
-The implementation is in the `lesson-2` crate under four test stages: `s01_shallow_merge`, `s02_rewrite_children`, `s03_cascading_merge`, and `s04_parent_backlinks`, plus a `merge_state_tests` module that begins to probe the winner/task/statistics surface. Run them:
+The stages and tests are in the `optimizer-blog-lesson-2` crate: `s01_shallow_merge`, `s02_rewrite_children`, `s03_cascading_merge`, `s04_parent_backlinks`, and `merge_state_tests`. Run them:
 
 ```bash
 cargo test -p optimizer-blog-lesson-2
 ```
 
-If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the test cases in order. The structural lessons apply regardless of whether you use union-find, a worklist, parent backlinks, or a specialized data structure. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.
+If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the stages in order. The structural lessons apply to any memo design that permits equivalent groups to be discovered after insertion. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -43,7 +43,7 @@ This post works through the failures one stage at a time, using the code in the 
 
 The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions:
 
-```rust
+
 An illustrative sketch of the shallow merge (the real code uses
 `merge_group_shallow(merge_into, merge_from)` and redirects
 `merge_from -> merge_into`):
@@ -66,7 +66,7 @@ A redirect map makes representative lookup possible. It does not re-express stor
 # Stage 2: Rewriting Children Changes Identity
 
 The fix rewrites every expression that directly references the losing group.
-`s02_rewrite_children` demonstrates this. `merge_group_rewrite_only` scans every stored expression, selects those whose children contain `merge_from`, and rewrites those child IDs to `merge_to`.
+`s02_rewrite_children` demonstrates this. `merge_group_rewrite_only` scans every stored expression, selects those whose children contain `merge_from`, and rewrites those child IDs to `merge_into`.
 
 But the test `rewriting_children_can_create_duplicate_expressions` reveals a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memo Mayhem: #2 Lessons Learned from Building an Optimizer"
+title: "A Good Memo Table is Hard to Build: #2 Lessons Learned from Building an Optimizer"
 pubDate: "2026-08-08T12:00:00-05:00"
 tags: ["optimizer-lesson", "optimizer", "Rust", "query optimization", "cascades"]
 description: "Group merging looks local. It is not. Four escalating failures and what they teach about memo-table design."

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -72,7 +72,7 @@ The fix rewrites every expression that directly references the losing group.
 /// replaces children using the redirect map.
 ```
 
-But the tests `rewriting_children_can_create_duplicate_expressions` and `merged_groups_collapse_to_one` reveal a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
+But the test `rewriting_children_can_create_duplicate_expressions` reveals a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 
 > **Congruence closure:** If `key(e1) == key(e2)`, the groups containing `e1` and `e2` must be merged.
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -41,17 +41,11 @@ This post works through the failures one stage at a time, using the code in the 
 
 # Stage 1: The Shallow Merge
 
-The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions:
-
-
-An illustrative sketch of the shallow merge (the real code uses
-`merge_group_shallow(merge_into, merge_from)` and redirects
-`merge_from -> merge_into`):
+The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions. The real shallow merge delegates to `move_group`:
 
 ```rust
 fn merge_group_shallow(&mut self, merge_into: GroupId, merge_from: GroupId) -> GroupId {
-    self.group_redirect.insert(merge_from, merge_into);
-    merge_into
+    self.move_group(merge_into, merge_from)
 }
 ```
 
@@ -80,7 +74,7 @@ After a merge rewrites children and produces new collisions, those new merges ma
 
 `s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix resolves collisions until no new merges appear.
 
-The published code uses an explicit worklist that canonicalizes each discovered pair when processed and continues until the worklist is empty. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning every expression for each individual merge, while a cascade can still touch a large part of the memo.
+The published code uses an explicit LIFO worklist, canonicalizes each pair when processed, and reverses newly discovered pairs to preserve recursive depth-first order. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning every expression for each individual merge, while a cascade can still touch a large part of the memo.
 
 # Stage 4: Parent Backlinks
 
@@ -93,7 +87,7 @@ To avoid scanning the entire memo for affected expressions, the code maintains a
 Other query optimizers have encountered this problem:
 
 - The public **Columbia** source does not implement `MergeGroups` under its `UNIQ` configuration.
-- **Apache Calcite** eagerly rewrites with parent backlinks and merges costs and metadata during a recursive set merge.
+- **Apache Calcite** uses parent backlinks to rename affected parents, recursively merges sets exposed by renaming, and propagates best-cost changes.
 - **Doris Nereids** transfers parent links, enforcers, logical and physical expressions, lowest-cost and property entries, and conditionally copies statistics; duplicate `GroupExpression` merge combines property-cost tables and rule masks.
 - **Greenplum ORCA** marks duplicates during search and performs a global rehash at a quiescent phase boundary.
 - **CockroachDB** interns immutable expressions and adds explored alternatives to an explicit target group, so it exposes no general group-merge operation.

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -66,13 +66,7 @@ A redirect map makes representative lookup possible. It does not re-express stor
 # Stage 2: Rewriting Children Changes Identity
 
 The fix rewrites every expression that directly references the losing group.
-`s02_rewrite_children` demonstrates this. An illustrative sketch:
-
-```rust
-/// Illustrative — see `s02_rewrite_children.rs` for the real
-/// implementation which traverses expressions by group and
-/// replaces children using the redirect map.
-```
+`s02_rewrite_children` demonstrates this.
 
 But the test `rewriting_children_can_create_duplicate_expressions` reveals a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -98,7 +98,7 @@ Other query optimizers have encountered this problem:
 
 - The public **Columbia** source does not implement `MergeGroups` under its `UNIQ` configuration.
 - **Apache Calcite** eagerly rewrites with parent backlinks and merges costs and metadata during a recursive set merge.
-- **Doris Nereids** merges costs, properties, rule masks, winners, statistics, and DPhyp state during group consolidation.
+- **Doris Nereids** transfers parent links, enforcers, logical and physical expressions, lowest-cost and property entries, and conditionally copies statistics; duplicate `GroupExpression` merge combines property-cost tables and rule masks.
 - **Greenplum ORCA** marks duplicates during search and performs a global rehash at a quiescent phase boundary.
 - **CockroachDB** interns immutable expressions and adds explored alternatives to an explicit target group, so it exposes no general group-merge operation.
 - **egg** tracks parent e-nodes, queues affected parents on union, restores congruence lazily in `rebuild`, and merges analysis data under a separate policy.

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -15,76 +15,222 @@ description: "Group merging looks local. It is not. Four escalating failures and
 
 This is the second part of my blog post series, "Lessons Learned from Building a Query Optimizer". In [Lesson 1](/blog/2025-02-06-optimizer-lesson-01/), we built a generic plan representation with group IDs and left `merge_group` as an unimplemented stub. Today we finish that function.
 
-Merging two memo groups means choosing one representative and repairing every expression and index that refers to either group. The result is not a single patch. It is four escalating stages, each exposing a structural truth about memo tables.
-
-Group merging is a narrow problem: when two group IDs become equivalent, reconcile every piece of state that depends on them. This post is about the _structure_ of that reconciliation, not about cost models, cardinality estimation, or the search algorithm. Those matter, but they sit on top of a memo that must first be correct.
-
-You can find the code for this post at [skyzh/optimizer-lessons](https://github.com/skyzh/optimizer-lessons), branch `skyzh/lesson-2-memo-table`.
+The runnable code is in [skyzh/optimizer-lessons](https://github.com/skyzh/optimizer-lessons/tree/e45b4ad0abefa0902f559dc07163fdf21f1f01a2/lesson-2), pinned to the merged commit used by this post.
 
 </div>
 
-# The Setup
+Suppose an optimizer has already inserted these two expressions:
 
-In Lesson 1, we introduced a memo table indexed by group ID. Each expression is stored under a group. The optimizer's job is to explore equivalent expressions within a group. Two operations matter here: `add_expr` (which Lesson 1 implemented) and `merge_group` (which it left as a stub).
+```
+Project[x](!G1)  in G3
+Project[x](!G2)  in G4
+```
+
+Later, a rule proves that `G1` and `G2` are equivalent. The tempting implementation moves the expressions from `G2` into `G1`, records `G2 -> G1`, and returns. The API call looks finished.
+
+Then the optimizer inserts `Project[x](!G1)` again. Instead of finding the existing expression, the memo creates another group. A task created before the merge still holds `G4`. A winner may still name an expression that was removed as a duplicate. One local call has left several data structures with different answers to the same question: which group does this expression belong to?
+
+That is the motivating failure. A group merge is not a vector append. It changes an equivalence relation that the memo has materialized in expression keys, child IDs, reverse indexes, parent links, stale handles, and optimization state. Each copy of that fact must be reconciled, and one repair can reveal another merge.
+
+This post develops the implementation in four stages. Each stage fixes the smallest visible bug, exposes the next invariant, and carries the same example one level farther.
+
+# A Concrete Memo Model
+
+A **group** represents a set of logically equivalent plans. A **memo expression** stores one operator whose children are group IDs. If `!G1` represents a scan, then `Project[x](!G1)` says that this projection can use any plan in `G1` as its child.
+
+The demo exposes two central operations:
 
 ```rust
 /// Insert an expression into the memo.
 fn add_expr(&mut self, expr: MemoExpr) -> (GroupId, ExprId);
 
 /// Declare that two groups are equivalent.
-fn merge_group(&mut self, a: GroupId, b: GroupId) -> GroupId;
+fn merge_group(&mut self, merge_into: GroupId, merge_from: GroupId) -> GroupId;
 ```
 
-The problem is that a group does not just contain expressions. The memo and its indexes materialize an equivalence relation across many data structures: stored expressions that reference child group IDs, redirect maps that point from merged groups to their representatives, hash tables that locate a group by its expression key, and state like winners and costs. When two groups become equivalent, every index that saw them as distinct must be reconciled.
+`add_expr` deduplicates by expression key. In this lesson, the key is the operator, its private data, and the **canonical** representative of each child group:
 
-This post works through the failures one stage at a time, using the code in the `optimizer-blog-lesson-2` crate. Each stage contains focused tests for one missing invariant.
+```
+key(e) = (operator(e), private_data(e), find(child_1), ..., find(child_n))
+```
 
-# Stage 1: The Shallow Merge
+For example, once `find(G2) == G1`, these expressions have the same key:
 
-The crate's `s01_shallow_merge` module shows what happens with the simplest merge. Redirect one group to another, but do not rewrite any expressions. The real shallow merge delegates to `move_group`:
+```
+Project[x](!G1)
+Project[x](!G2)  -> canonicalize children -> Project[x](!G1)
+```
+
+Therefore their owner groups must also be equivalent:
+
+```
+key(e1) == key(e2)  =>  find(owner(e1)) == find(owner(e2))
+```
+
+This is the congruence rule that drives the whole lesson. Representative lookup is necessary, but lookup alone does not repair an expression already stored under its old hash key.
+
+The memo keeps several views of this state:
+
+| Structure | Question it answers | What a merge can invalidate |
+| --- | --- | --- |
+| `groups` and `expr_to_group` | Which expressions belong to a group? | owner IDs and the surviving winner |
+| `exprs` | What operator and child groups does an expression contain? | child IDs that name the losing group |
+| `expr_to_id` | Have we already stored this expression key? | every entry whose canonical child changes |
+| `parent_exprs` | Which expressions directly use this group? | both ends of the reverse index |
+| `group_redirect` and `expr_redirect` | Where should an old handle resolve now? | redirect chains and deleted duplicates |
+
+The demo also stores one winner per group. It deliberately does not model tasks, statistics, physical properties, or rule-application state. A production optimizer must define merge policies for every such field; this lesson makes that boundary explicit instead of pretending the structural algorithm settles it.
+
+# The Running Example
+
+We will carry one two-level expression graph through all four stages:
+
+| Group | Expression |
+| --- | --- |
+| `G1` | `Scan(t1)` |
+| `G2` | `Scan(t1-alias)` |
+| `G3` | `Project[x](!G1)` |
+| `G4` | `Project[x](!G2)` |
+| `G5` | `Project[y](!G3)` |
+| `G6` | `Project[y](!G4)` |
+
+The scan expressions have different keys, but an external rule has established that their groups are equivalent. We call `merge_group(G1, G2)`, choosing `G1` as the representative.
+
+Canonicalizing `Project[x](!G2)` changes its child to `G1`. That expression now collides with `Project[x](!G1)`, so `G4` must merge into `G3`. Canonicalizing `Project[y](!G4)` then changes its child to `G3`, so `G6` must merge into `G5`. A leaf equivalence has propagated to the root.
+
+![Before a group merge, two Project expressions have different child-group keys. After G2 redirects to G1, canonicalization makes the keys identical and requires their owner groups to merge.](01-canonicalization.svg)
+
+_The redirect answers `find(G2)`, while canonicalization repairs stored keys. When two repaired keys become equal, their owner groups become the next merge._
+
+# Stage 1: A Redirect Leaves Stale Children
+
+The `s01_shallow_merge` module implements the tempting first version. It moves the losing group's expressions and remembers the redirect:
 
 ```rust
-fn merge_group_shallow(&mut self, merge_into: GroupId, merge_from: GroupId) -> GroupId {
+pub fn merge_group_shallow(
+    &mut self,
+    merge_into: GroupId,
+    merge_from: GroupId,
+) -> GroupId {
     self.move_group(merge_into, merge_from)
 }
 ```
 
-The test `shallow_merge_leaves_stale_children` demonstrates the failure. Two expressions are created in different groups. After merging the groups, a new expression that should be structurally equivalent to an existing one ends up in a different group because the existing expression still references stale child IDs. The memo now has two groups representing expressions that should have been deduplicated.
+This is enough for `representative(G2)` to return `G1`. It is not enough for expressions that already contain `G2`. In the running example, `Project[x](!G2)` still carries the losing ID and remains indexed under that stale key.
 
-The invariant we broke:
+The test `shallow_merge_leaves_stale_children` makes the symptom observable. After the shallow merge, inserting an expression with the canonical child does not match the stale stored expression. The memo creates a duplicate group, and `check_invariants` reports the stale child.
 
-> **Key invariance:** If two expressions are structurally identical after resolving their child groups to canonical representatives, they must share a group.
+The missing invariant is:
 
-A redirect map makes representative lookup possible. It does not re-express stored child IDs. After the merge, the old expression still carries the original child IDs, so a new expression with the same structure but resolved to the post-merge representatives produces a different key. The deduplication fails.
+> Every child ID stored in a live memo expression is already its canonical group representative.
 
-# Stage 2: Rewriting Children Changes Identity
+A union-find or redirect map can make `find(G2)` cheap. It still cannot change a key already stored in a hash table. The entry must be removed under its old key, rewritten, and inserted under its new key.
 
-The fix rewrites every expression that directly references the losing group.
-`s02_rewrite_children` demonstrates this. `merge_group_rewrite_only` scans every stored expression, selects those whose children contain `merge_from`, and rewrites those child IDs to `merge_into`.
+# Stage 2: Rewriting a Key Can Create a Collision
 
-But the test `rewriting_children_can_create_duplicate_expressions` reveals a new problem: two expressions that used to be different can become identical after rewriting. When that happens, their groups must also be merged, or the memo violates:
+The `s02_rewrite_children` module scans every stored expression, selects those whose children contain `merge_from`, and rewrites those children to `merge_into`. In the running example, it changes:
 
-> **Congruence closure:** If `key(e1) == key(e2)`, the groups containing `e1` and `e2` must be merged.
+```
+Project[x](!G2)  ->  Project[x](!G1)
+```
 
-After rewriting, the code must check whether any rewritten expression now collides with an existing key and, if so, add that pair to the pending merges.
+Now the child IDs are canonical, but the repair has changed the expression's identity. The rewritten key already belongs to the expression in `G3`. If the reverse index simply overwrites its old entry, two equal expressions remain in different groups and one expression becomes unreachable through the index.
 
-# Stage 3: Cascading Merges
+The test `rewriting_children_can_create_duplicate_expressions` stops at exactly this failure. It finds two groups containing `Project[x](!G1)` after the rewrite.
 
-After a merge rewrites children and produces new collisions, those new merges may rewrite more children and produce more collisions. The process repeats until no new merges appear: a fixed-point computation.
+The missing invariant is congruence closure:
 
-`s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix resolves collisions until no new merges appear.
+> If two canonical expressions have the same key, their owner groups must have the same representative.
 
-The published code uses an explicit LIFO worklist, canonicalizes each pair when processed, and reverses newly discovered pairs to preserve recursive depth-first order. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions without scanning the memo requires tracking which expressions reference each group; backlinks make each individual merge targeted, although a cascade can still touch much of the memo.
+The repair therefore cannot end at “rewrite the expression.” On collision it must choose one expression ID, redirect the duplicate expression handle, remove the duplicate from its owner group, and schedule a merge of the two owner groups. For the running example, rewriting the `G4` expression discovers the pair `(G3, G4)`.
 
-# Stage 4: Parent Backlinks
+# Stage 3: A Collision Starts Another Merge
 
-To avoid scanning the entire memo for affected expressions, the code maintains a reverse index: `parent_exprs: HashMap<GroupId, BTreeSet<ExprId>>`. When an expression is inserted, its ID is added to the parent set of every child group. When a merge occurs, only the expressions that directly reference the losing group need rewriting; the surviving group inherits the losing group's parent set.
+Merging `G4` into `G3` rewrites expressions that contain `G4`. That changes `Project[y](!G4)` into `Project[y](!G3)`, which already exists in `G5`. The second collision discovers `(G5, G6)`. In a deeper tree, the same pattern can repeat thousands of times.
 
-`s04_parent_backlinks` tests this mechanism. The backlinks make rewriting targeted, but they are themselves a new invariant to maintain. And they do not solve the remaining problems: the `merge_state_tests` module probes stale group and expression handles plus winner selection. Tasks, statistics, property-envelope state, and rule-application state are not modeled. Each new state field added to the memo adds another merge policy to define.
+This is a fixed-point computation: keep processing newly discovered group equivalences until no collision produces another pair.
+
+The `s03_cascading_merge` module uses a correctness-first implementation that scans the memo for affected expressions. It keeps pending pairs on an explicit `Vec` worklist:
+
+```
+push (merge_into, merge_from)
+
+while the worklist is not empty:
+    pop one pair
+    resolve both IDs to their current representatives
+    skip the pair if both sides already agree
+    move the losing group into the representative
+    rewrite every affected expression to canonical children
+    remove any duplicate expression revealed by a rewritten key
+    push the duplicate expression owners as new group merges
+```
+
+The published implementation uses LIFO `Vec::pop()`. It reverses newly discovered pairs before extending the worklist, preserving the recursive depth-first order of the earlier implementation without putting a deep cascade on the call stack. The test `deep_unary_parent_cascade_uses_bounded_stack` exercises a chain of 7,000 parent expressions. `cascading_merge_handles_cycles_and_repeated_children` covers self-cycles and an expression that uses the same child twice.
+
+![Merging G2 into G1 rewrites its direct Project parent, discovers a G3 and G4 collision, then processes that pair and discovers G5 and G6. Parent backlinks identify each affected expression, while the worklist carries newly discovered group pairs.](02-worklist-backlinks.svg)
+
+_The worklist makes termination state explicit. Canonicalizing each popped pair also makes repeated or already-resolved pairs harmless._
+
+At this point the structural algorithm is correct, but each individual merge finds parents by scanning every expression. That is the next boundary, not a reason to weaken the fixed-point rule.
+
+# Stage 4: Parent Backlinks Target Each Rewrite
+
+To find affected expressions without scanning the whole memo, `s04_parent_backlinks` maintains the inverse edge:
+
+```rust
+parent_exprs: HashMap<GroupId, BTreeSet<ExprId>>
+```
+
+When an expression is inserted, its ID is added to the parent set of each child group. Before redirecting a losing group, `merge_group` clones that group's parent set. Those are the only expressions whose hash keys can change because of this individual merge.
+
+For every affected expression, the implementation performs the same careful sequence:
+
+1. remove the expression's old reverse-index entry;
+2. remove its old parent backlinks;
+3. canonicalize its child IDs;
+4. either insert the new key and backlinks, or redirect it to the existing expression on collision; and
+5. add any newly equivalent owner groups to the worklist.
+
+The order matters. If the code redirects `G2` before capturing `parent_exprs[G2]`, a representative-based lookup may jump to `G1` and lose the exact set of expressions that named the losing group. If it adds the new backlinks before removing the old ones, an unchanged child can lose its new edge and a changed child can retain a stale edge.
+
+`backlinks_track_direct_parent_expressions` also checks the set semantics: an expression that uses one group twice is still one parent expression, not two. `backlinks_are_repaired_through_cascading_merges` verifies the reverse index after both the `G2 -> G1` and `G4 -> G3` repairs.
+
+Backlinks improve the starting point of each rewrite. They do not make a cascading merge globally local or linear. A leaf merge can still expose collisions through a large part of the memo, and the backlink index is itself another invariant that every insertion, rewrite, collision, and deletion must maintain.
+
+# Stale Handles and Winners Are Part of the Contract
+
+Structural repair is not enough if optimizer work can outlive a merge. A task might begin with `G4` and `ExprId(7)`, yield, and finish after those objects have been merged away. Rejecting the old IDs would make group merging a hidden lifetime boundary for every caller.
+
+The demo instead treats IDs as stable handles:
+
+- `group_redirect` maps an old group to its current representative;
+- `expr_redirect` maps a removed duplicate expression to the retained expression;
+- `representative`, `representative_expr`, `group_of_expr`, and `expr` resolve handles before use; and
+- `set_winner` resolves both the group and expression before installing a result.
+
+The test `stale_group_and_expression_ids_remain_usable` creates handles before a merge and uses them afterward to set a winner. The winner lands in the canonical group and names the retained expression. `merging_groups_keeps_the_cheaper_winner` gives each input group a winner and verifies that `move_group` preserves the lower-cost one.
+
+This is a policy, not a universal answer. Another optimizer could invalidate outstanding work and reschedule it. What matters is that the policy is explicit and tested. Adding statistics, required physical properties, rule masks, or task state creates the same question again: join the state, invalidate it, redirect it, or reject the merge. “Move the expressions” is never a complete state policy.
+
+# The Four Stages as One Algorithm
+
+![The four stages progress from a shallow group redirect, to rewriting canonical child IDs, to collision-driven fixed-point merges, and finally to targeted rewrites through parent backlinks plus stale-handle and winner repair.](03-stage-map.svg)
+
+_Each stage preserves the previous repair. The final implementation still redirects groups, canonicalizes keys, resolves collisions to a fixed point, and maintains every reverse edge._
+
+The final structural contract can be stated as five invariants:
+
+1. **Canonical children:** every child ID in every live expression is a group representative.
+2. **Unique expression keys:** `expr_to_id` contains exactly one live expression for each canonical key.
+3. **Congruent owners:** equal canonical keys imply the same representative owner group.
+4. **Exact backlinks:** `parent_exprs[g]` is exactly the set of live expressions that name `g` as a child.
+5. **Resolvable handles and state:** old group/expression IDs reach live representatives, and winner state follows the declared merge policy.
+
+`check_invariants` reconstructs enough of these relationships to catch drift: it checks redirect chains, group membership, reverse-index sizes and entries, canonical child IDs, winner ownership, and a freshly rebuilt backlink map. The stage tests intentionally stop at broken intermediate implementations, while the final tests require the invariant checker to succeed.
 
 # The Bigger Picture
 
-Other query optimizers have encountered this problem:
+Other optimizer designs draw the boundary in different places:
 
 - The public **Columbia** source does not implement `MergeGroups` under its `UNIQ` configuration.
 - **Apache Calcite** uses parent backlinks to rename affected parents, recursively merges sets exposed by renaming, and propagates best-cost changes.
@@ -93,26 +239,27 @@ Other query optimizers have encountered this problem:
 - **CockroachDB** interns immutable expressions and adds explored alternatives to an explicit target group, so it exposes no general group-merge operation.
 - **egg** tracks parent e-nodes, queues affected parents on union, restores congruence lazily in `rebuild`, and merges analysis data under a separate policy.
 
-The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not specify how to find affected parents, repair hash-table keys, detect cascading collisions, or handle stale winners and state. Those details become the implementation.
+The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not prescribe a concrete contract for finding affected parents, repairing hash keys, processing cascading collisions, or reconciling stale handles and optimizer state. Those choices belong to the implementation.
 
-In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize them. Current optd uses append-only handles; its join-ordering pass builds a hypergraph per join-group root and uses a DP table keyed by `NodeSet`; this is a different design from the older per-`GroupId` memoization path.
+In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize representative lookup. Current optd takes a different path for join ordering: it builds a hypergraph for each join-group root and runs dynamic programming over `NodeSet` keys. It should not be described as a newer version of the general memo merge shown here.
+
+The comparison is not “which optimizer found the one correct data structure?” The useful question is which states can become equivalent after insertion, which indexes materialize that equivalence, and when the system repairs them. A specialized dynamic program or constrained insertion API can remove the need for a general `merge_group`; a general memo must pay the reconciliation cost somewhere.
 
 # What We Learned
 
-Group merging in a memo table is a structural reconciliation that touches stored expressions, redirects, hash keys, parent indexes, and winners. Four invariants fell out of the escalating stages:
+A good memo table is hard to build because it stores the same equivalence fact in several useful forms. The group map makes alternatives easy to enumerate. The expression hash index makes deduplication fast. Parent backlinks find affected expressions. Redirects keep old handles usable. Winners keep optimization results. Each index helps one operation and adds one obligation to merging.
 
-1. **Expression-key invariance:** after a merge, structurally identical expressions (with children resolved to representatives) must be in the same group. A redirect map alone does not guarantee this.
+The running example shows the complete chain:
 
-2. **Congruence closure:** rewriting children can make previously distinct expressions identical, producing new group equivalences that must also be merged.
+1. merging `G2` into `G1` leaves a stale `Project[x](!G2)` unless child IDs are rewritten;
+2. rewriting it to `Project[x](!G1)` collides with the expression in `G3`, so `G4` must merge into `G3`;
+3. that merge rewrites `Project[y](!G4)`, discovers the `G5`/`G6` collision, and keeps the worklist alive; and
+4. backlinks target each rewrite, while redirects and winner policies preserve the rest of the API contract.
 
-3. **Cascading reach:** a single merge can trigger a cascade of new equivalences, requiring a fixed-point traversal. The published implementation uses an explicit canonicalizing fixed-point worklist; union-find with hash-key repair is an alternative design.
-
-4. **Parent indexing:** finding affected expressions without scanning the entire memo requires reverse indexes from groups to their parent expressions. These indexes are themselves a new invariant.
-
-The stages and tests are in the `optimizer-blog-lesson-2` crate: `s01_shallow_merge`, `s02_rewrite_children`, `s03_cascading_merge`, `s04_parent_backlinks`, and `merge_state_tests`. Run them:
+Run the eleven Lesson 2 tests with:
 
 ```bash
 cargo test -p optimizer-blog-lesson-2
 ```
 
-If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the stages in order. The structural lessons apply to any memo design that permits equivalent groups to be discovered after insertion. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.
+If your optimizer permits equivalent groups to be discovered after insertion, do not treat `merge_group` as a local container operation. Write down the canonical-key rule, the owner-congruence rule, every reverse index, and the state policy. Then test the smallest collision that forces each one. The fixed-point worklist is the mechanism; the real invariant is that every materialized view of equivalence agrees when it becomes empty.

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -1,5 +1,5 @@
 ---
-title: "A Good Memo Table is Hard to Build: #2 Lessons Learned from Building an Optimizer"
+title: "A Good Memo Table Is Hard to Build"
 pubDate: "2026-08-08T12:00:00-05:00"
 tags: ["optimizer-lesson", "optimizer", "Rust", "query optimization", "cascades"]
 description: "Group merging looks local. It is not. Four escalating failures and what they teach about memo-table design."

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -74,7 +74,7 @@ After a merge rewrites children and produces new collisions, those new merges ma
 
 `s03_cascading_merge` demonstrates this with the test `expression_collisions_cascade_to_parent_groups`. A two-level chain of expressions is set up so that merging two leaf groups causes their parents' expressions to collide, which in turn cascades upward. The fix resolves collisions until no new merges appear.
 
-The published code uses an explicit LIFO worklist, canonicalizes each pair when processed, and reverses newly discovered pairs to preserve recursive depth-first order. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions requires tracking which expressions reference each group — backlinks avoid scanning every expression for each individual merge, while a cascade can still touch a large part of the memo.
+The published code uses an explicit LIFO worklist, canonicalizes each pair when processed, and reverses newly discovered pairs to preserve recursive depth-first order. A union-find with a hash-key repair loop is an alternative. Finding all affected expressions without scanning the memo requires tracking which expressions reference each group; backlinks make each individual merge targeted, although a cascade can still touch much of the memo.
 
 # Stage 4: Parent Backlinks
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -224,7 +224,3 @@ cargo test -p lesson-2
 ```
 
 If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the test cases in order. The structural lessons apply regardless of whether you use union-find, a worklist, parent backlinks, or a specialized data structure. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.
-
----
-
-*Thanks to the optimizer-lessons team for code review and test design. The Lesson 2 implementation is by Forge; this post was drafted by Sentinel and reviewed by the editorial lane.*

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -19,20 +19,70 @@ The runnable code is in [skyzh/optimizer-lessons](https://github.com/skyzh/optim
 
 </div>
 
-Suppose an optimizer has already inserted these two expressions:
+In Lesson 1, we established a way to look up expressions in the memo table. An expression's lookup key contains its operator, its private data, and the group IDs of its children. Before inserting an expression, the memo looks up that key. If the key already exists, we reuse its group; otherwise, we create a new group.
+
+This contract is simple as long as group IDs never change meaning. Now consider a memo with two always-true filters above a scan:
 
 ```
-Project[x](!G1)  in G3
-Project[x](!G2)  in G4
+G1: Filter[true](!G2)
+G2: Filter[true](!G3)
+G3: Scan(t1)
 ```
 
-Later, a rule proves that `G1` and `G2` are equivalent. The tempting implementation moves the expressions from `G2` into `G1`, records `G2 -> G1`, and returns. The API call looks finished.
+Here, `G1:` means that the expression to its right belongs to group `G1`, and `!G2` means that the expression uses any plan from `G2` as its child.
 
-Then the optimizer inserts `Project[x](!G1)` again. Instead of finding the existing expression, the memo creates another group. A task created before the merge still holds `G4`. A winner may still name an expression that was removed as a duplicate. One local call has left several data structures with different answers to the same question: which group does this expression belong to?
+Suppose we apply the rule `Filter[true](child) -> child` to both filters. The rule says that each filter and its child produce the same result, so the memo records the child group as another alternative:
 
-That is the motivating failure. A group merge is not a vector append. It changes an equivalence relation that the memo has materialized in expression keys, child IDs, reverse indexes, parent links, stale handles, and optimization state. Each copy of that fact must be reconciled, and one repair can reveal another merge.
+```
+G1: !G2, Filter[true](!G2)
+G2: !G3, Filter[true](!G3)
+G3: Scan(t1)
+```
 
-This post develops the implementation in four stages. Each stage fixes the smallest visible bug, exposes the next invariant, and carries the same example one level farther.
+The first rewrite tells us that `G1 == G2`. The second tells us that `G2 == G3`. By transitivity, `G1 == G2 == G3`.
+
+This is already a mess. `Scan(t1)` is now reachable through three group IDs even though a group is supposed to be the single home for a set of equivalent plans. A first attempt might choose `G1` as the surviving group, move every expression into it, and delete `G2` and `G3`:
+
+```
+G1: Filter[true](!G2), Filter[true](!G3), Scan(t1)
+```
+
+But collecting group members is not enough. The two filter expressions still refer to `G2` and `G3`. If those groups now redirect to `G1`, the stored expressions must be repaired as well:
+
+```
+G1: Filter[true](!G1), Filter[true](!G1), Scan(t1)
+```
+
+The two filters now have the same lookup key, so only one of them should remain. Future lookup requests need the same treatment. Looking up `Filter[true](!G3)` must first turn its child into the surviving `G1`; otherwise, the memo will miss `Filter[true](!G1)` and insert a duplicate.
+
+The repair also reaches expressions outside the three groups. Suppose another group contains a projection over `G3`:
+
+```
+G4: Project[col A](!G3)
+```
+
+The projection still belongs to `G4`, but its stored child must change to `G1`:
+
+```
+G4: Project[col A](!G1)
+```
+
+The memo must update both the expression and the lookup entry built from it. It must also canonicalize an incoming query for `Project[col A](!G3)` to `Project[col A](!G1)` so that old group handles and new lookups find the same expression.
+
+One repaired parent can force another group merge. Extend the example with two equivalent projections and their parents:
+
+```
+G4: Project[col A](!G3)
+G5: Project[col A](!G2)
+G6: Limit[10](!G4)
+G7: Limit[10](!G5)
+```
+
+After `G2` and `G3` redirect to `G1`, both projection keys become `Project[col A](!G1)`. That collision tells us that `G4 == G5`. Once those groups merge, both limit keys become `Limit[10](!G4)`, which tells us that `G6 == G7`. A merge at the scan has cascaded upward through two levels of parents.
+
+This is why `merge_group` is not a vector append. The memo needs a way to find expressions that refer to a losing group, canonicalize stored expressions and incoming lookup keys, resolve duplicate keys, and keep processing the new group equivalences it discovers. The rest of this post asks how to perform that repair until every view of the memo agrees again.
+
+We will repeat the same rhythm: implement the locally obvious fix, break it with the smallest counterexample, name the missing invariant, and strengthen the implementation.
 
 # A Concrete Memo Model
 
@@ -83,7 +133,7 @@ The demo also stores one winner per group. It deliberately does not model tasks,
 
 # The Running Example
 
-We will carry one two-level expression graph through all four stages:
+The filter chain exposed the problem. To trace the repair without self-referential filters, we will carry one acyclic, two-level expression graph through all four implementation stages:
 
 | Group | Expression |
 | --- | --- |
@@ -125,6 +175,8 @@ The missing invariant is:
 > Every child ID stored in a live memo expression is already its canonical group representative.
 
 A union-find or redirect map can make `find(G2)` cheap. It still cannot change a key already stored in a hash table. The entry must be removed under its old key, rewritten, and inserted under its new key.
+
+This correctness-first repair needs exclusive access to the memo while an expression's old key is removed and its new key is installed. During that short interval, the expression store and its indexes intentionally disagree. Without an inverse index from a child group to its parent expressions, finding every row affected by the update also requires a scan of the memo.
 
 # Stage 2: Rewriting a Key Can Create a Collision
 
@@ -181,6 +233,8 @@ To find affected expressions without scanning the whole memo, `s04_parent_backli
 parent_exprs: HashMap<GroupId, BTreeSet<ExprId>>
 ```
 
+The backlink stores expression IDs rather than owner group IDs because expressions are the objects whose children and hash keys must be rewritten. Two expressions in one owner group may refer to the same child independently.
+
 When an expression is inserted, its ID is added to the parent set of each child group. Before redirecting a losing group, `merge_group` clones that group's parent set. Those are the only expressions whose hash keys can change because of this individual merge.
 
 For every affected expression, the implementation performs the same careful sequence:
@@ -195,7 +249,7 @@ The order matters. If the code redirects `G2` before capturing `parent_exprs[G2]
 
 `backlinks_track_direct_parent_expressions` also checks the set semantics: an expression that uses one group twice is still one parent expression, not two. `backlinks_are_repaired_through_cascading_merges` verifies the reverse index after both the `G2 -> G1` and `G4 -> G3` repairs.
 
-Backlinks improve the starting point of each rewrite. They do not make a cascading merge globally local or linear. A leaf merge can still expose collisions through a large part of the memo, and the backlink index is itself another invariant that every insertion, rewrite, collision, and deletion must maintain.
+Backlinks change parent discovery for one merge from scanning all memo expressions to visiting the losing group's direct parents. They do not make a cascading merge globally local or linear. A leaf merge can still expose collisions through a large part of the memo, and the backlink index is itself another invariant that every insertion, rewrite, collision, and deletion must maintain.
 
 # Stale Handles and Winners Are Part of the Contract
 
@@ -239,9 +293,20 @@ Other optimizer designs draw the boundary in different places:
 - **CockroachDB** interns immutable expressions and adds explored alternatives to an explicit target group, so it exposes no general group-merge operation.
 - **egg** tracks parent e-nodes, queues affected parents on union, restores congruence lazily in `rebuild`, and merges analysis data under a separate policy.
 
+These designs choose different places to pay for the same reconciliation:
+
+| Strategy | Parent discovery | Repair timing | Main cost |
+| --- | --- | --- | --- |
+| Full rewrite | Scan the memo | Immediate | Global work and exclusive mutation |
+| Parent backlinks | Inverse-edge index | Immediate | More indexes and mutation invariants |
+| Deferred rehash | Scan and rebuild globally | Quiescent phase | Stop-the-world work and phase constraints |
+| Constrained grouping | Avoid arbitrary union | During controlled rule insertion | Duplicate semantic groups and missed sharing |
+
 The Cascades paper identifies cross-group duplicates and discusses merging pattern memories. It does not prescribe a concrete contract for finding affected parents, repairing hash keys, processing cascading collisions, or reconciling stale handles and optimizer state. Those choices belong to the implementation.
 
-In my own optimizer work, the public `optd-original` code uses redirect maps to resolve merged groups and notes that union-find could optimize representative lookup. Current optd takes a different path for join ordering: it builds a hypergraph for each join-group root and runs dynamic programming over `NodeSet` keys. It should not be described as a newer version of the general memo merge shown here.
+In my own optimizer work, `optd-original` learned these invariants one bug at a time. Merge ordering could make source expressions disappear before migration. Replacement collisions then required merging their owner groups. Union-find made representative lookup cheaper but still left stored children stale. The correctness-first rewrite canonicalized every expression and recursively handled collisions; later fixes routed winner updates through representatives and retained the cheaper winner. Each locally reasonable repair exposed another materialized view of the equivalence relation.
+
+Current optd takes a different path for join ordering: it builds a hypergraph for each join-group root and runs dynamic programming over `NodeSet` keys. It should not be described as a newer version of the general memo merge shown here.
 
 The comparison is not “which optimizer found the one correct data structure?” The useful question is which states can become equivalent after insertion, which indexes materialize that equivalence, and when the system repairs them. A specialized dynamic program or constrained insertion API can remove the need for a general `merge_group`; a general memo must pay the reconciliation cost somewhere.
 

--- a/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
+++ b/src/content/blog/2026-08-08-optimizer-lesson-02.mdx
@@ -220,7 +220,7 @@ Group merging in a memo table is not a vector append. It is a structural reconci
 The implementation is in the `lesson-2` crate under four test stages: `s01_shallow_merge`, `s02_rewrite_children`, `s03_cascading_merge`, and `s04_parent_backlinks`, plus a `merge_state_tests` module that begins to probe the winner/task/statistics surface. Run them:
 
 ```bash
-cargo test -p lesson-2
+cargo test -p optimizer-blog-lesson-2
 ```
 
 If you are building a Cascades optimizer, do not leave `merge_group` as a stub. Work through the test cases in order. The structural lessons apply regardless of whether you use union-find, a worklist, parent backlinks, or a specialized data structure. The invariant is the same: equivalence is global even when the API call looks local, and every materialized index must agree on the answer.


### PR DESCRIPTION
## Why

Lesson 1 leaves memo-group merging as a stub, while the earlier Lesson 2 draft moved too quickly from the API to four fixes. Readers need one concrete failure and one running graph that make the global reconciliation problem visible.

## What changed

- carry one expression graph through stale child IDs, key collisions, fixed-point group merges, and parent-backlink repair
- state the canonical-key, congruent-owner, backlink, stale-handle, and winner invariants against the merged Lesson 2 implementation
- add three source-controlled diagrams for canonicalization, collision propagation, and the four-stage progression

AI-Assisted: GPT-5.6 Sol + Sentinel
