### PR TITLE
Repair key-value separation overview

### DIFF
--- a/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="92 184 823 403" width="823" height="403">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.1" viewBox="92 184 823 403" width="823" height="403">
   <defs>
     <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <g>
@@ -8,7 +8,7 @@
       </g>
     </marker>
   </defs>
-  <g id="write-badger" stroke="none" fill-opacity="1" fill="none" stroke-opacity="1" stroke-dasharray="none">
+  <g id="write-badger" stroke-opacity="1" fill-opacity="1" stroke-dasharray="none" fill="none" stroke="none">
     <title>write-badger</title>
     <rect fill="white" x="92" y="184" width="823" height="403"/>
     <g id="write-badger_Layer_1">
@@ -17,64 +17,64 @@
         <rect x="214.292" y="323.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.292" y="323.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.292 335.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_5">
         <text transform="translate(176 335.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">L0</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">L0</tspan>
         </text>
       </g>
       <g id="Graphic_8">
         <rect x="214.5" y="375.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.5" y="375.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 386.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_7">
         <rect x="287.09484" y="375.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="287.09484" y="375.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(292.09484 386.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_10">
         <text transform="translate(176.208 386.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">L1</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">L1</tspan>
         </text>
       </g>
       <g id="Graphic_13">
         <rect x="286.88684" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="286.88684" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(291.88684 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_12">
         <rect x="359.4817" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="359.4817" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(364.4817 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_11">
         <text transform="translate(176 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">Ln</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">Ln</tspan>
         </text>
       </g>
       <g id="Graphic_15">
         <rect x="214.292" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.292" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.292 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_16">
         <rect x="432.0765" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="432.0765" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(437.0765 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Line_20">
@@ -82,92 +82,92 @@
       </g>
       <g id="Graphic_21">
         <text transform="translate(98 290)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">On Disk</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15" xml:space="preserve">On Disk</tspan>
         </text>
       </g>
       <g id="Graphic_22">
         <text transform="translate(98 261.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">In Memory</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15" xml:space="preserve">In Memory</tspan>
         </text>
       </g>
       <g id="Graphic_23">
         <rect x="214.5" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.5" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_24">
         <rect x="287.09484" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="287.09484" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(292.09484 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_25">
         <rect x="359.6897" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="359.6897" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(364.6897 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_27">
         <rect x="632" y="323.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="632" y="323.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(637 335.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_30">
         <rect x="706.2732" y="323.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="706.2732" y="323.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(711.2732 335.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_31">
         <rect x="632" y="375.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="632" y="375.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(637 386.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_32">
         <rect x="706.2732" y="375.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="706.2732" y="375.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(711.2732 386.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_34">
         <rect x="632" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="632" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(637 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_33">
         <rect x="706.2732" y="426.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="706.2732" y="426.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(711.2732 438.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15">vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.773159" y="15" xml:space="preserve">vLog</tspan>
         </text>
       </g>
       <g id="Graphic_38">
         <rect x="543.0121" y="323.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="543.0121" y="323.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(548.0121 335.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.557159" y="15">WAL</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.557159" y="15" xml:space="preserve">WAL</tspan>
         </text>
       </g>
       <g id="Graphic_39">
         <rect x="527.91726" y="217.5" width="93" height="28.447998" fill="white"/>
         <rect x="527.91726" y="217.5" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(532.91726 222.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="5.876" y="15">key + vptr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="5.876" y="15" xml:space="preserve">key + vptr</tspan>
         </text>
       </g>
       <g id="Line_41">
@@ -181,30 +181,30 @@
       </g>
       <g id="Graphic_46">
         <text transform="translate(668 248.412)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">1. Write large key-value pairs to vLog </tspan>
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392">as file number + offset (foreground)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">1. Write large key-value pairs to vLog </tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392" xml:space="preserve">as file id + length + offset (foreground)</tspan>
         </text>
       </g>
       <g id="Graphic_47">
         <text transform="translate(219.5 189.582)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">3. Write to memtables (foreground)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">3. Write to memtables (foreground)</tspan>
         </text>
       </g>
       <g id="Graphic_48">
         <text transform="translate(252 294.25)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">4. Flush memtables to disk as SSTs (background)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">4. Flush memtables to disk as SSTs (background)</tspan>
         </text>
       </g>
       <g id="Graphic_49">
         <text transform="translate(219.292 479.093)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">5. Compact data to lower levels (background) </tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">5. Compact data to lower levels (background) </tspan>
         </text>
       </g>
       <g id="Graphic_50">
         <rect x="620.91726" y="217.5" width="86.176" height="28.447998" fill="white"/>
         <rect x="620.91726" y="217.5" width="86.176" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(625.91726 222.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="19.272001" y="15">value</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="19.272001" y="15" xml:space="preserve">value</tspan>
         </text>
       </g>
       <g id="Line_52">
@@ -212,28 +212,35 @@
       </g>
       <g id="Graphic_53">
         <text transform="translate(392.92284 264.804)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">2. Write to WAL (foreground)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">2. Write to WAL (foreground)</tspan>
         </text>
       </g>
       <g id="Graphic_56">
-        <rect x="214.5" y="558.052" width="93" height="28.447998" fill="white"/>
-        <rect x="214.5" y="558.052" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <rect x="214.5" y="558.052" width="66.624" height="28.447998" fill="white"/>
+        <rect x="214.5" y="558.052" width="66.624" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 563.052)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="14.244" y="15">File No.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6.832" y="15" xml:space="preserve">File Id</tspan>
         </text>
       </g>
       <g id="Graphic_55">
-        <rect x="307.5" y="558.052" width="93" height="28.447998" fill="white"/>
-        <rect x="307.5" y="558.052" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(312.5 563.052)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="19.988" y="15">Offset</tspan>
+        <rect x="281.124" y="558.052" width="62.81032" height="28.447998" fill="white"/>
+        <rect x="281.124" y="558.052" width="62.81032" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(286.124 563.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="4.893159" y="15" xml:space="preserve">Offset</tspan>
         </text>
       </g>
       <g id="Graphic_54">
         <rect x="214.5" y="529.604" width="186" height="28.447998" fill="white"/>
         <rect x="214.5" y="529.604" width="186" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 534.604)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="74.072" y="15">vptr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="74.072" y="15" xml:space="preserve">vptr</tspan>
+        </text>
+      </g>
+      <g id="Graphic_57">
+        <rect x="343.9343" y="558.052" width="56.56568" height="28.447998" fill="white"/>
+        <rect x="343.9343" y="558.052" width="56.56568" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(348.9343 563.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="10.090841" y="15" xml:space="preserve">Len</tspan>
         </text>
       </g>
     </g>

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
@@ -223,9 +223,9 @@
         </text>
       </g>
       <g id="Graphic_55">
-        <rect x="281.124" y="558.052" width="62.81032" height="28.447998" fill="white"/>
-        <rect x="281.124" y="558.052" width="62.81032" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(286.124 563.052)" fill="black">
+        <rect x="337.68968" y="558.052" width="62.81032" height="28.447998" fill="white"/>
+        <rect x="337.68968" y="558.052" width="62.81032" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(342.68968 563.052)" fill="black">
           <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="4.893159" y="15" xml:space="preserve">Offset</tspan>
         </text>
       </g>
@@ -237,9 +237,9 @@
         </text>
       </g>
       <g id="Graphic_57">
-        <rect x="343.9343" y="558.052" width="56.56568" height="28.447998" fill="white"/>
-        <rect x="343.9343" y="558.052" width="56.56568" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(348.9343 563.052)" fill="black">
+        <rect x="281.124" y="558.052" width="56.56568" height="28.447998" fill="white"/>
+        <rect x="281.124" y="558.052" width="56.56568" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(286.124 563.052)" fill="black">
           <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="10.090841" y="15" xml:space="preserve">Len</tspan>
         </text>
       </g>

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/write-titan.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/write-titan.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="92 181 693 465" width="693" height="465">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.1" viewBox="92 181 693 465" width="693" height="465">
   <defs>
     <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <g>
@@ -8,7 +8,7 @@
       </g>
     </marker>
   </defs>
-  <g id="write-titan" stroke="none" fill-opacity="1" fill="none" stroke-opacity="1" stroke-dasharray="none">
+  <g id="write-titan" stroke-opacity="1" fill-opacity="1" stroke-dasharray="none" fill="none" stroke="none">
     <title>write-titan</title>
     <rect fill="white" x="92" y="181" width="693" height="465"/>
     <g id="write-titan_Layer_1">
@@ -17,64 +17,64 @@
         <rect x="214.292" y="382.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.292" y="382.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.292 394.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_5">
         <text transform="translate(176 394.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">L0</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">L0</tspan>
         </text>
       </g>
       <g id="Graphic_8">
         <rect x="214.5" y="434.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.5" y="434.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 445.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_7">
         <rect x="287.09484" y="434.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="287.09484" y="434.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(292.09484 445.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_10">
         <text transform="translate(176.208 445.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">L1</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">L1</tspan>
         </text>
       </g>
       <g id="Graphic_13">
         <rect x="286.88684" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="286.88684" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(291.88684 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_12">
         <rect x="359.4817" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="359.4817" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(364.4817 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_11">
         <text transform="translate(176 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15">Ln</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6394885e-19" y="15" xml:space="preserve">Ln</tspan>
         </text>
       </g>
       <g id="Graphic_15">
         <rect x="214.292" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.292" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.292 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Graphic_16">
         <rect x="432.0765" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="432.0765" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(437.0765 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15">SST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="11.445159" y="15" xml:space="preserve">SST</tspan>
         </text>
       </g>
       <g id="Line_20">
@@ -82,92 +82,92 @@
       </g>
       <g id="Graphic_21">
         <text transform="translate(98 290)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">On Disk</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15" xml:space="preserve">On Disk</tspan>
         </text>
       </g>
       <g id="Graphic_22">
         <text transform="translate(98 261.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">In Memory</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15" xml:space="preserve">In Memory</tspan>
         </text>
       </g>
       <g id="Graphic_23">
         <rect x="214.5" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="214.5" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_24">
         <rect x="287.09484" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="287.09484" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(292.09484 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_25">
         <rect x="359.6897" y="210.974" width="62.81032" height="41.5" fill="white"/>
         <rect x="359.6897" y="210.974" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(364.6897 213.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15">Mem </tspan>
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448">Table</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="8.317159" y="15" xml:space="preserve">Mem </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.589159" y="33.448" xml:space="preserve">Table</tspan>
         </text>
       </g>
       <g id="Graphic_27">
         <rect x="528" y="382.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="528" y="382.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(533 394.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_30">
         <rect x="602.27316" y="382.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="602.27316" y="382.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(607.27316 394.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_31">
         <rect x="528" y="434.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="528" y="434.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(533 445.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_32">
         <rect x="602.27316" y="434.026" width="62.81032" height="41.5" fill="white"/>
         <rect x="602.27316" y="434.026" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(607.27316 445.552)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_34">
         <rect x="528" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="528" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(533 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_33">
         <rect x="602.27316" y="485.552" width="62.81032" height="41.5" fill="white"/>
         <rect x="602.27316" y="485.552" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(607.27316 497.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15">Blob</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.813159" y="15" xml:space="preserve">Blob</tspan>
         </text>
       </g>
       <g id="Graphic_38">
         <rect x="684.0948" y="382.5" width="62.81032" height="41.5" fill="white"/>
         <rect x="684.0948" y="382.5" width="62.81032" height="41.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(689.0948 394.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.557159" y="15">WAL</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.557159" y="15" xml:space="preserve">WAL</tspan>
         </text>
       </g>
       <g id="Graphic_39">
         <rect x="669" y="217.5" width="93" height="28.447998" fill="white"/>
         <rect x="669" y="217.5" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(674 222.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x=".988" y="15">key + value</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x=".988" y="15" xml:space="preserve">key + value</tspan>
         </text>
       </g>
       <g id="Line_41">
@@ -181,61 +181,68 @@
       </g>
       <g id="Graphic_47">
         <text transform="translate(219.5 186)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">2. Write to memtables (foreground)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">2. Write to memtables (foreground)</tspan>
         </text>
       </g>
       <g id="Graphic_48">
         <text transform="translate(249.894 285.716)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">3. Flush memtables to disk as SSTs + Blob files (background)</tspan>
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392">Store file number + offset in SSTs.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">3. Flush memtables to disk as SSTs + Blob files (background)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392" xml:space="preserve">Store file number + length + offset in SSTs.</tspan>
         </text>
       </g>
       <g id="Graphic_49">
         <text transform="translate(215.5 538.093)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">4. Compact data to lower levels (background) </tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">4. Compact data to lower levels (background) </tspan>
         </text>
       </g>
       <g id="Graphic_53">
         <text transform="translate(533 263.608)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">1. Write to WAL (foreground)</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">1. Write to WAL (foreground)</tspan>
         </text>
       </g>
       <g id="Graphic_55">
         <rect x="199.40516" y="323.5" width="93" height="28.447998" fill="white"/>
         <rect x="199.40516" y="323.5" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(204.40516 328.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="5.876" y="15">key + vptr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="5.876" y="15" xml:space="preserve">key + vptr</tspan>
         </text>
       </g>
       <g id="Graphic_56">
         <rect x="292.40516" y="323.5" width="66.624" height="28.447998" fill="white"/>
         <rect x="292.40516" y="323.5" width="66.624" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(297.40516 328.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.496" y="15">value</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="9.496" y="15" xml:space="preserve">value</tspan>
         </text>
       </g>
       <g id="Line_57">
         <line x1="359.02916" y1="337.724" x2="518.76975" y2="399.67056" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Graphic_58">
-        <rect x="214.5" y="617.052" width="93" height="28.447998" fill="white"/>
-        <rect x="214.5" y="617.052" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <rect x="214.5" y="617.052" width="67.59858" height="28.447998" fill="white"/>
+        <rect x="214.5" y="617.052" width="67.59858" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 622.052)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="14.244" y="15">File No.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="1.5432897" y="15" xml:space="preserve">File No.</tspan>
         </text>
       </g>
       <g id="Graphic_59">
-        <rect x="307.5" y="617.052" width="93" height="28.447998" fill="white"/>
-        <rect x="307.5" y="617.052" width="93" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(312.5 622.052)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="19.988" y="15">Offset</tspan>
+        <rect x="282.09858" y="617.052" width="67.59858" height="28.447998" fill="white"/>
+        <rect x="282.09858" y="617.052" width="67.59858" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(287.09858 622.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.28729" y="15" xml:space="preserve">Offset</tspan>
         </text>
       </g>
       <g id="Graphic_60">
         <rect x="214.5" y="588.604" width="186" height="28.447998" fill="white"/>
         <rect x="214.5" y="588.604" width="186" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 593.604)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="74.072" y="15">vptr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="74.072" y="15" xml:space="preserve">vptr</tspan>
+        </text>
+      </g>
+      <g id="Graphic_61">
+        <rect x="349.69716" y="617.052" width="50.80284" height="28.447998" fill="white"/>
+        <rect x="349.69716" y="617.052" width="50.80284" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(354.69716 622.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="7.209421" y="15" xml:space="preserve">Len</tspan>
         </text>
       </g>
     </g>

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/write-titan.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/write-titan.svg
@@ -187,7 +187,7 @@
       <g id="Graphic_48">
         <text transform="translate(249.894 285.716)" fill="black">
           <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13" xml:space="preserve">3. Flush memtables to disk as SSTs + Blob files (background)</tspan>
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392" xml:space="preserve">Store file number + length + offset in SSTs.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="29.392" xml:space="preserve">Store file number + offset + length in SSTs.</tspan>
         </text>
       </g>
       <g id="Graphic_49">

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -48,7 +48,7 @@ In this article, unless otherwise stated, we assume that the storage engine has 
 
 First, let's look at how a conventional LSM storage engine handles writes. When the engine receives a write, it records the key-value pair in both the memtable and the WAL (Write-Ahead Log). The memtable often uses a skip list. The WAL makes the memtable's contents recoverable after a server failure; once the required WAL record is durable, the engine can acknowledge the write as persisted.
 
-The engine performs two main kinds of background work: flushing memtables to disk and compacting the LSM tree. It may have one mutable memtable and several immutable memtables waiting to flush. When a memtable reaches its size limit, the engine writes it as an SST; its WAL can be removed after no live memtable depends on it. An SST stores ordered key-value pairs in compressed blocks, with indexes and often Bloom filters to speed up reads.
+The engine performs two main kinds of background work: flushing memtables to disk and compacting the LSM tree. It may have one mutable memtable and several immutable memtables waiting to flush. When a memtable reaches its size limit, the engine writes it as an SST; its WAL can be removed after no live memtable depends on it. An SST stores ordered key-value pairs in blocks, which may be compressed, with indexes and often Bloom filters to speed up reads.
 
 Level 0 of the LSM tree consists of multiple SST files whose key ranges may overlap. In a leveled design, files within each level from level 1 onward have non-overlapping key ranges. If a level exceeds its size limit, the storage engine compacts selected files with overlapping files in the next level. As a result, data generally moves toward lower levels over time.
 
@@ -87,9 +87,9 @@ Because a v-SST uses SST format, its large values are sorted by key and can use 
 
 </div>
 
-Titan is a RocksDB plugin, so its foreground path follows RocksDB. Its background path resembles TerarkDB's, but it stores large values in blob files. A blob file contains key-value records in key order and compresses each record individually. For a separated value, Titan stores `<key, <fileno, offset, size>>` in the LSM tree.
+Titan is a RocksDB plugin, so its foreground path follows RocksDB. Its background path resembles TerarkDB's, but it stores large values in blob files. A blob file contains key-value records in key order and can compress each record. For a separated value, Titan stores `<key, <fileno, offset, size>>` in the LSM tree.
 
-BlobDB has a similar write path and also stores ordered, per-record-compressed values in blob files. Its LSM blob index contains the record type, file number, offset, size, and compression metadata.
+BlobDB has a similar write path and also stores ordered values with per-record compression when enabled. Its LSM blob index contains the record type, file number, offset, size, and compression metadata.
 
 ## Comparison of Write Paths
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Key-Value Separation in LSM Storage Engines"
 pubDate: "2023-12-31T18:00:00+08:00"
+updatedDate: "2026-08-09T00:00:00-07:00"
 tags: ["LSM", "Log-Structured", "Storage Engine", "Key-Value Separation"]
 description: "In this blog post, we walk through several different implementations of key-value separation in LSM storage engines."
 socialImage: "/images/2023-12-31-lsm-kv-separation-overview-social.png"
@@ -116,7 +117,7 @@ Once large values live outside the LSM tree, the engine needs a separate way to 
 
 ![Garbage collection in Badger](gc-badger.svg)
 
-Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger v3 and later persist these statistics in the `DISCARD` file; Badger v2 used an internal LSM key instead.
+Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger persists these statistics in the `DISCARD` file.
 
 Applications decide when to call `RunValueLogGC(discardRatio)`. The discard statistics guide selection of at most one candidate file per call; they do not trigger a rewrite automatically. During a rewrite, Badger checks each record's exact internal key/version and current LSM value pointer. It skips records that have been deleted, superseded, or no longer point to that location. Live values are appended to a new vLog file, and their updated pointers are written back to the LSM tree.
 
@@ -191,9 +192,7 @@ With key-value separation, the read path gains an out-of-line value lookup.
 
 Badger generally searches the memtables and LSM levels for the newest version at or below the read timestamp; an exact requested timestamp can end the search early. It then decodes the vptr and reads an out-of-line value directly from the vLog.
 
-Badger's iterator walks keys in sorted order, while values above the configured threshold occupy write-order offsets in the vLog. If write order and key order differ, a range scan that materializes those values can lose spatial locality. Badger mitigates this with configurable value prefetch: the checked v4.9.6 defaults fetch a window of 100 iterator values concurrently, while key-only or sparse scans can disable prefetch and fetch selected values on demand. This is a workload-dependent tradeoff, not proof that every Badger range scan is slow; insertion order, value size and threshold, cache state, scan length, compression, prefetch settings, and the storage device all affect the result.
-
-Historically, Badger's 2017 launch benchmark found value-materializing range iteration slower than RocksDB on one AWS i3.large setup despite prefetch, and left the shortfall as an open optimization problem. WiscKey's FAST '16 results were also conditional: with a randomly loaded database, tiny values lost to LevelDB on a long scan, while larger values won. These measurements explain the concern but do not establish a current cross-engine ranking.
+Badger's iterator returns keys in sorted order, but large values sit at write-order offsets in the vLog. When write order is random relative to key order, a range scan can lose locality and perform poorly. Badger mitigates this with configurable value prefetch, which defaults to 100 values; results still depend on the workload and write order.
 
 ## TerarkDB
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -13,27 +13,27 @@ heroImage: "/images/2023-12-31-lsm-kv-separation-overview-banner.png"
 
 # Introduction
 
-General-purpose LSM storage engines, such as LevelDB and RocksDB, store a set of user-written key-value pairs together in an ordered SST (Sorted String Table). During the compaction process, the engine merges the upper level SSTs with the lower level SSTs to generate a new SST file. In this process, both the keys and values inside the SST are rewritten, resulting in significant write amplification. If the size of the values is much larger than the keys, the write amplification caused by compaction can introduce substantial overhead.
+General-purpose LSM storage engines, such as LevelDB and RocksDB, store user-written keys and values together in ordered SSTs (Sorted String Tables). During compaction, the engine merges SSTs from one level with overlapping SSTs in another level to produce new files. This process rewrites both keys and values, resulting in significant write amplification. If values are much larger than keys, rewriting them can introduce substantial overhead.
 
-In WiscKey (FAST '16), the authors proposed an SSD-friendly design for LSM tree-based storage engines. It reduces write amplification by separating keys and values.
-Key-value separation involves storing large values elsewhere and storing a value pointer (vptr) in the LSM tree pointing to the location of the value. In WiscKey, this place where the value is stored is called the Value Log (vLog). Consequently, during LSM tree compaction, there is no need to rewrite the values, only the organization of the key indexes needs to be rearranged. This greatly reduces write amplification and mitigates SSD wear out.
+In WiscKey (FAST '16), the authors proposed an SSD-friendly LSM-tree design that reduces write amplification by separating keys from values. Large values are stored elsewhere, while the LSM tree stores a value pointer (vptr) to each value's location. WiscKey calls this separate storage the value log (vLog). LSM-tree compaction can then reorganize key indexes without rewriting the values themselves, reducing write amplification and SSD wear.
 
-The idea of key-value separation sounds straightforward, but in practical implementation, many issues need to be considered:
-* How should the content of the vLog be organized? How to compress the vLog?
-* After a user deletes a value, how to reclaim the garbage in the vLog?
-* When reclaiming garbage, how to update the vptr in the LSM tree?
-* How to address the performance impact on scans caused by key-value separation?
+The idea sounds straightforward, but a practical implementation must answer several questions:
 
-Now, it has been seven years since the publication of the WiscKey paper. In the industry, a number of key-value separation LSM storage engine implementations have emerged. In this article, I will introduce four open-source implementations of key-value separation storage engines, compare their differences, and thereby highlight the tradeoffs in implementing key-value separation, providing readers with more insights for selecting a key-value separation storage engine in scenarios with large values.
+* How should the vLog be organized and compressed?
+* After a user deletes a value, how should the engine reclaim the resulting garbage?
+* When reclaiming garbage, how should the engine update vptrs in the LSM tree?
+* How should the engine manage the effect of key-value separation on range scans?
 
-* [BadgerDB](https://github.com/dgraph-io/badger) is the storage engine that is closest to the key-value separation described in the WiscKey paper. BadgerDB is the storage engine for the Dgraph graph database, written in simple and efficient Go language.
-* [TerarkDB](https://github.com/bytedance/terarkdb) is a storage engine developed by Terark (now acquired by ByteDance), based on RocksDB 5.x. TerarkDB is currently being used internally at ByteDance.
-* [Titan](https://github.com/tikv/titan) is a storage engine provided as a RocksDB plugin, compatible with all interfaces of RocksDB 6.x, developed mainly by PingCAP. Titan is currently available for use in TiKV.
-* [BlobDB](https://github.com/facebook/rocksdb/tree/main/db/blob) is a component inside RocksDB that supports separating large values into a separate BlobDB.
+Between WiscKey's publication in 2016 and this English article in 2023, several key-value-separated LSM storage engines emerged. In this article, I will introduce four open-source implementations and compare their design tradeoffs. These differences can help readers choose an engine for workloads with large values.
+
+* [BadgerDB](https://github.com/dgraph-io/badger) is the closest of these engines to the key-value separation described in the WiscKey paper. It is written in Go and was developed for the Dgraph graph database.
+* [TerarkDB](https://github.com/bytedance/terarkdb) was developed by Terark, which ByteDance acquired. The checked source is a fork of RocksDB 5.18.3.
+* [Titan](https://github.com/tikv/titan) is a RocksDB plugin used by TiKV. Its repository documents compatibility with specific TiKV and RocksDB versions rather than promising compatibility with every RocksDB interface.
+* [BlobDB](https://github.com/facebook/rocksdb/tree/main/db/blob) is integrated into RocksDB and stores large values in separate blob files.
 
 <div style={{ "border": "1px solid", "padding": "0.5em" }}>
 
-If you are reading this blog post, you might also be interested in [mini-lsm](https://github.com/skyzh/mini-lsm), a tutorial on building an LSM-tree storage engine written by me, based on my previous experience with RocksDB and other key-value storage engines.
+If you are reading this post, you might also be interested in [mini-lsm](https://github.com/skyzh/mini-lsm), my tutorial on building an LSM-tree storage engine. It draws on my experience with RocksDB and other key-value storage engines.
 
 </div>
 
@@ -45,180 +45,202 @@ In this article, unless otherwise stated, we assume that the storage engine has 
 
 ![Writing to LSM](write-normal-lsm.svg)
 
-First, let's take a look at how normal LSM storage engines handle write requests. When a write request from a user is received, the engine directly writes the key-value pair to both the memtable and the WAL (Write-Ahead Log). The memtable typically uses a skip list to store key-value pairs. The WAL is used for persistence to recover the information in the memtable after a server failure. At this point, the user can be notified that the write operation has been persisted.
+First, let's look at how a conventional LSM storage engine handles writes. When the engine receives a write, it records the key-value pair in both the memtable and the WAL (Write-Ahead Log). The memtable often uses a skip list. The WAL makes the memtable's contents recoverable after a server failure; once the required WAL record is durable, the engine can acknowledge the write as persisted.
 
-The background operations of the LSM engine mainly include two tasks: flushing the memtable to disk and doing compaction on the LSM tree. At any given time, only one memtable is actively being written to in memory, while the other memtables are immutable. When the memtable in memory exceeds its limit, the engine converts the contents of the memtable into an SST (Sorted String Table) and flushes it to disk, also deleting the WAL. SST is a file that stores ordered key-value pairs. The data in SST is stored in blocks and compressed within each block. After writing the content of the key-value pair, there are several index blocks at the end of the SST, which record the key at the beginning of each data block for quick positioning of the key. SST may include other structures like Bloom Filters to accelerate queries.
+The engine performs two main kinds of background work: flushing memtables to disk and compacting the LSM tree. There is typically one mutable memtable per column family and there may be several immutable memtables waiting to flush. When a memtable reaches its size limit, the engine turns it into an SST and writes it to disk. A WAL can be removed only after no live memtable depends on it. An SST stores ordered key-value pairs in data blocks, often with per-block compression. Its index entries delimit those blocks and direct lookups to candidate blocks. SSTs may also contain structures such as Bloom filters to avoid unnecessary reads.
 
-The level 0 of the LSM tree consists of multiple SST files, and the key ranges of the SST files in level 0 may overlap. From level 1 onwards, the key ranges of SST files in the same level do not overlap. If any of the levels exceed the size limit, the storage engine will compact files in that level with the files in a lower level, and then move them to a lower level. As a result, the keys and values written by the user gradually move to the lowest level of the engine over time.
+Level 0 of the LSM tree consists of multiple SST files whose key ranges may overlap. In a leveled design, files within each level from level 1 onward have non-overlapping key ranges. If a level exceeds its size limit, the storage engine compacts selected files with overlapping files in the next level. As a result, data generally moves toward lower levels over time.
 
-When the LSM tree is initially empty, if SST files are compacted from level 0 to L1, ..., and finally, the last level, level-by-level, it introduces some unnecessary write amplification. Therefore, most LSM storage engines provide the ability to compact to the base level (Lbase). In this case, the size of the SST files that each level can accommodate is dynamically adjustable. SST files may be directly flushed from level 0 to level 6, reducing the write amplification when the LSM tree is initially populated.
+Moving data through every level while an LSM tree is still small would introduce unnecessary write amplification. Many engines therefore choose a dynamic base level (Lbase) according to the current database size and configuration. Early data can move directly from level 0 to that base level instead of passing through every intermediate level.
 
 ## BadgerDB
 
-In BadgerDB, large values are directly written to the value log (vLog) when the user requests to write them. The entire process is shown in the following diagram.
+BadgerDB writes large values directly to its value log (vLog), as shown below.
 
 ![Writing to Badger](write-badger.svg)
 
-When a user requests to write a key-value pair to Badger, if the value is smaller than a threshold, the entire process is the same as normal LSM engines. If the value is greater than or equal to the threshold, the writing process is as follows:
+When a user writes a key-value pair to Badger, values below a configurable threshold stay inline in the LSM tree. For a value at or above the threshold, the write path is as follows:
 
-- Large values are first appended to the vLog. BadgerDB has only one active vLog. When a vLog exceeds the specified size, the engine creates a new file as a new vLog. Therefore, Badger uses multiple vLog files to store the large values written by users. Each vLog file stores the large values and their corresponding keys in the order they were written.
-- After writing to the vLog, the location of the value in the vLog and the vLog file number can be obtained. BadgerDB writes the `<key, <fileno, offset>>` as a key-value pair to the WAL, memtable, and LSM tree, following the same process as normal LSM engines.
+- Badger first appends the key and value to the active vLog. When that file reaches its configured size, the engine creates a new one. Each vLog therefore contains records in write order.
+- Badger then stores a pointer containing the vLog file id, the value's byte length, and its offset (`<fid, len, offset>`) in the LSM entry. The pointer lets a read address the value directly; Badger does not search the vLog by key.
 
 ## TerarkDB
 
 ![Writing to TerarkDB](write-terarkdb.svg)
 
-Since TerarkDB is based on RocksDB, the entire write process is consistent with RocksDB in the foreground stage. The key-value pairs are written to the memtable and WAL, and then the memtable is flushed to disk in the background. Compared to Badger, the value needs to be written to the WAL in the foreground and to the v-SST (Value SST) during the flush. This process introduces an additional 1x write amplification.
+Because TerarkDB is based on RocksDB, its foreground write path follows RocksDB: key-value pairs enter the memtable and WAL, and the memtable is later flushed to disk. Compared with Badger's direct vLog path, a large value is written once to the WAL and again to the v-SST (Value SST) during the flush, adding one full-value write.
 
-During the background flushing process, TerarkDB splits the memtable based on the size of the values. The small values are bundled together with the keys into an SST, following the same process as normal LSM engines. The large values and their corresponding keys are written to the v-SST as an SST. Since the v-SST includes index blocks, it allows for quick positioning of the value based on the key during queries. In the LSM tree, TerarkDB only stores the keys corresponding to the large values and the file number where the value is located, `<key, fileno>`, without storing the offset of the large value.
+During a background flush, TerarkDB separates entries according to value size. Small values remain with their keys in an SST. Large values and their keys are written to a v-SST. Because the v-SST has index blocks, a query can locate a value by key. For a separated value, the LSM tree stores the key and the v-SST file number, `<key, fileno>`, without an offset.
 
-Because large values are stored in SST format, large values in a single v-SST in TerarkDB are sorted by key. At the same time, with the help of existing tools in RocksDB, TerarkDB can perform block-level compression on v-SST. In this case, the default key-value separation threshold in TerarkDB is usually set to a smaller value, around 512B, while BadgerDB sets this default value to 4K.
+Because a v-SST uses SST format, its large values are sorted by key and can use RocksDB's block-level compression. The pinned TerarkDB source sets its separation threshold to 512 B. Thresholds in these engines are configurable and version-dependent, so the comparison table below does not present them as timeless defaults.
 
 ## Titan and BlobDB
 
 ![Writing to Titan / BlobDB](write-titan.svg)
 
-Titan is a plugin for RocksDB, so the overall foreground process is almost the same as RocksDB. The background process is similar to TerarkDB, with the only difference being the way large values are stored. Titan stores large values in a special format called blob file. The blob file contains ordered key-value pairs where each pair is compressed individually. Therefore, during the flush process, the storage format in the LSM tree for large values in Titan is `<key, <fileno, offset>>`.
+Titan is a RocksDB plugin, so its foreground path follows RocksDB. Its background path resembles TerarkDB's, but it stores large values in blob files. A blob file contains key-value records in key order and compresses each record individually. For a separated value, Titan stores `<key, <fileno, offset, size>>` in the LSM tree.
 
-BlobDB uses the same storage layout and implements a similar write path to Titan. The blob file also contains ordered key-value pairs which are compressed per-record.
+BlobDB has a similar write path and also stores ordered, per-record-compressed values in blob files. Its LSM blob index contains the record type, file number, offset, size, and compression metadata (and an expiration field for TTL values).
 
 ## Comparison of Write Paths
 
-| Storage Engine                 | BadgerDB                  | TerarkDB                      | Titan / BlobDB                           |
-| ------------------------------ | -------------------------| ---------------------------- | ------------------------------ |
-| Foreground Writing of Large Values <br/> (affects write amplification) | Written directly to vLog  | Written to WAL, then flushed to v-SST | Written to WAL, then flushed to blob file |
-| value ptr contents                  | `<fileno,  offset>`     | `<fileno>`                   | `<fileno,  offset>`             |
-| Sorting of vLog <br/> (affects scan performance)    | In the order of writes  | Sorted by key                | Sorted by key                    |
-| Compression granularity of vLog <br/> (affects space amplification) | Per-record             | Per-block                    | Per-record                       |
-| Whether vLog includes indexes  | No                        | Yes                          | No                               |
-| Default key-value separation threshold | 4K                        | 512B                          | 4K                               |
+<div class="table-container">
+
+| Storage Engine | BadgerDB | TerarkDB | Titan / BlobDB |
+| --- | --- | --- | --- |
+| Foreground writing of large values <br/> (affects write amplification) | Written directly to vLog | Written to WAL, then flushed to v-SST | Written to WAL, then flushed to blob file |
+| Value pointer contents | `<fid, len, offset>` | `<fileno>` | Titan: `<fileno, offset, size>`<br/>BlobDB: `<type, fileno, offset, size, compression>` |
+| Out-of-line value order <br/> (one input to key-range locality) | Write order | Key order | Key order |
+| Compression granularity <br/> (affects space amplification) | Per record | Per block | Per record |
+| Out-of-line storage includes an index | No | Yes | No |
+
+</div>
 
 # Garbage Collection
 
-After users delete or update keys, normal LSM engines will delete the old records during the compaction process, as shown in the following figure: If the compaction process finds that there are different version of key-value pairs with in the upper and lower layers, or if there are delete tombstones in the upper layer, the engine will delete the keys in the lower layer and keep only one copy of the key-value in the new SST.
+After users update or delete keys, a conventional LSM engine can discard obsolete records during compaction, as shown below. If compaction finds several versions of a key or a deletion tombstone, it drops old versions and tombstones only when no supported snapshot or lower-level data can still require them.
 
 ![Compaction in normal LSM](compaction-normal-lsm.svg)
 
-After separating large values from the LSM tree, we need to handle garbage collection of the large values to reduce the amount of garbage data on the disk and minimize space amplification caused by key-value separation.
+Once large values live outside the LSM tree, the engine needs a separate way to reclaim obsolete records and control space amplification.
 
 ## Garbage Collection in BadgerDB
 
 ![Garbage collection in Badger](gc-badger.svg)
 
-As shown in the above figure, BadgerDB stores the garbage estimation value of each vLog in the `DISCARD` file. When a user updates or deletes a key, the counter of the corresponding vLog file will be incremented by 1. When the counter reaches a certain threshold, the vLog file will be rewritten.
+Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger v3 and later persist these statistics in the `DISCARD` file; Badger v2 used an internal LSM key instead.
 
-During the vLog rewriting process, BadgerDB scans whether the current key being processed exists in the LSM tree. If it does not exist or has been updated, it will ignore that key.
+Applications decide when to call `RunValueLogGC(discardRatio)`. The discard statistics guide selection of at most one candidate file per call; they do not trigger a rewrite automatically. During a rewrite, Badger checks each record's exact internal key/version and current LSM value pointer. It skips records that have been deleted, superseded, or no longer point to that location. Live values are appended to a new vLog file, and their updated pointers are written back to the LSM tree.
 
-After the new vLog is generated, BadgerDB writes the new positions of these key-value pairs back to the LSM tree. Therefore, the GC process of BadgerDB will impact the user write throughput of the LSM tree. This leads to a question: if a user has already deleted a key, but during GC, the old value corresponding to this key is written back to the LSM tree, will it cause correctness issues when reading?
+Because those replacement pointers use the normal LSM write path, GC adds write traffic and can affect foreground throughput. It also raises a correctness question: could GC write an older value back after a concurrent update or deletion?
 
 ![Garbage collection consistency in Badger](gc-consistency-badger.svg)
 
-As shown in the above figure, BadgerDB internally stores keys as a combination of key + timestamp. When writing back to the LSM tree, BadgerDB does not need to consider whether the current key has been deleted or updated by the user. This does cause the new value (corresponding to the key-vptr) written by the user to be placed below the old value (corresponding to the key-vptr). However, during reading, BadgerDB scans all layers, which resolves this potential correctness issue. I will also explain this in more detail in the subsequent read path section.
+*Correctness boundary: while a vLog rewrite is active, a newer tombstone must remain in the LSM so it continues to shadow any older value pointer written back by GC.*
+
+Badger's internal keys contain a user key and version. GC writes an older internal key/version back with a new value pointer, so a newer update or tombstone must continue to win. Badger reads the newest visible version across the LSM. The checked 2026 source also prevents last-level compaction from discarding a tombstone created after a vLog rewrite began. That retention rule is necessary: older releases could resurrect a deleted value in a narrow compaction/GC race, which was fixed in June 2026.
 
 ## Compaction and Garbage Collection in TerarkDB
 
 ![Garbage collection in TerarkDB](gc-terarkdb.svg)
 
-In TerarkDB, v-SST garbage collection does not require writing back to the LSM tree, reducing the impact of GC on user foreground traffic.
+In TerarkDB, v-SST garbage collection does not need to write replacement pointers back through the foreground LSM write path, reducing its impact on foreground traffic.
 
-As shown in the above figure, TerarkDB selects v-SSTs that need to be garbage collected based on the garbage amount of each v-SST in the background. The GC process iterates through each key to confirm whether they have been deleted or updated in the LSM tree. After GC, new v-SSTs are produced. TerarkDB records the dependency relationships between v-SSTs in the MANIFEST. If the key accessed by the user points to an older v-SST, TerarkDB finds the latest v-SST based on the dependency relationships and reads the value from it. Overall, the special feature of TerarkDB is that garbage collection does not affect the write traffic in the foreground.
+In the background, TerarkDB selects v-SSTs according to their estimated garbage and checks each key against the LSM tree to see whether it has been deleted or updated. GC produces new v-SSTs and records dependencies between old and new files in the MANIFEST. If a lookup points to an older v-SST, TerarkDB follows those dependencies to the newest file and reads the value there. This design avoids writing every replacement file number through the foreground path.
 
 ![Compaction in TerarkDB](compaction-terarkdb.svg)
 
-During the LSM tree compaction process, TerarkDB also updates the file number. As shown in the figure above, if the engine detects that the file corresponding to a large value has been deleted during compaction, it writes the new file number into the SST generated by compaction based on the dependency relationships.
+During LSM-tree compaction, TerarkDB also refreshes file numbers. If the referenced v-SST has been replaced, the engine follows the dependency relationship and writes the new file number into the compaction output.
 
-In practical production environments, this GC method may cause the bottom layer of the LSM tree to depend on almost all v-SSTs, and a particular v-SST may be referenced by many SSTs, resulting in performance degradation. TerarkDB performs a special _rebuild_ compaction for these SSTs that have complex dependency relationships. During the rebuild process, the engine simplifies the dependency chain as much as possible to ensure the normal operation of the system.
+Over time, lower LSM levels may depend on many v-SSTs, and one v-SST may be referenced by many SSTs. TerarkDB performs a special _rebuild_ compaction to bound and shorten these dependency chains.
 
 ## Garbage Collection in Titan
 
-Titan's regular garbage collection (regular GC) adopts a similar strategy to BadgerDB, using statistics to determine which blob files to collect, and then rewriting the corresponding blob files and writing the new vptr back to the LSM tree. The entire process is shown in the following figure.
+Titan's regular garbage collection resembles Badger's: statistics identify candidate blob files, Titan rewrites their live records, and it writes new vptrs back to the LSM tree. The process is shown below.
 
 ![Regular garbage collection in Titan](gc-titan-regular.svg)
 
-Since Titan is developed as a plugin of RocksDB, it does not have access to the internal version number of each key. Therefore, when writing back to the LSM tree, it needs to register a WriteCallback to avoid race conditions where the GC process overwrites later user updates. This greatly impacts the user write throughput during the engine's GC process.
+Because Titan is a RocksDB plugin, it does not have direct access to every key's internal version. When writing replacement pointers, it registers a `WriteCallback` to prevent GC from overwriting a later user update. This adds write-path synchronization and can affect throughput; the magnitude depends on the workload.
 
-To solve this problem, Titan introduces another GC scheme called _level merge_, as shown in the figure below. During the background compaction process of the LSM tree, Titan rewrites the corresponding blob files and updates the vptr in the SST, without interfering with foreground user writes.
+Titan also offers an optional scheme called _Level Merge_, shown below. When enabled, compaction into the last two LSM levels can rewrite blob records and place updated blob indexes directly in the compaction output, avoiding a separate regular-GC pointer write-back.
 
 ![Level-merge garbage collection in Titan](gc-titan-level-merge.svg)
 
-Titan's Level Merge is only enabled in the last two levels of the LSM tree.
+Level Merge is off by default.
 
 ## Garbage Collection in BlobDB
 
-BlobDB uses a relatively simple garbage collection strategy. It defines two parameters for developers to set: GC threshold and GC age cutoff. When the age of a blob file is too old, the engine will trigger a compaction task that rewrites the blob file as well as the LSM tree SSTs. When the garbage rate in a blob file is too high, the engine will also trigger a compaction.
+RocksDB's integrated BlobDB garbage collection is optional and compaction-integrated. When enabled, the age cutoff selects an oldest fraction of blob files whose references may be relocated during ordinary LSM compaction; the cutoff does not itself trigger compaction. A separate force threshold can schedule targeted leveled compactions when the garbage ratio among eligible files is high enough.
 
 ![Compaction in BlobDB](compaction-blobdb.svg)
 
-BlobDB does not support directly compacting/garbage-collecting blob files. Blob files are only compacted when SSTs linking to the blob files are compacted.
+Blob files are not compacted independently. Live blobs are relocated only as their referencing SST entries are processed during LSM compaction.
+
+*The figure shows eligible blob files being rewritten as part of LSM compaction, not a standalone blob-file compaction.*
 
 ## Comparison of Garbage Collection Strategies
 
-| Storage Engine | BadgerDB          | TerarkDB           | Titan                                      | BlobDB |
-| -------------- | ----------------- | ------------------ | ------------------------------------------ | --- |
-| vLog GC Task   | Rewrite vLog, Write back to LSM | Merge v-SST + Rebuild | Merge blob files, Write back to LSM (Regular GC) | N/A |
-| Compaction Task | N/A | Update file numbers to the latest | Rewrite blob files (Level Merge)             |  Rewrite blob files |
+<div class="table-container">
+
+| Storage Engine | BadgerDB | TerarkDB | Titan | BlobDB |
+| --- | --- | --- | --- | --- |
+| Separate GC task | Rewrite vLog and write pointers back to LSM | Merge v-SST and rebuild dependencies | Regular GC rewrites blob files and writes pointers back to LSM | None |
+| LSM compaction work | Records discarded vLog bytes | Refreshes v-SST file numbers | Optional Level Merge rewrites blobs | Relocates live records from eligible blob files |
+
+</div>
 
 # Read Path of Large Values
 
-As shown in the figure below, in normal LSM storage engines, reading a single key requires traversing the memtable, L0 SST, and one of the SSTs in each subsequent level. Once the same key is encountered, the result can be returned to the user.
+For a point lookup, an LSM engine may inspect memtables, overlapping level-0 files, and at most one candidate file in each non-overlapping lower level. Bloom filters, caches, indexes, and an early visible result can avoid many of these probes. The engine must still respect sequence numbers, tombstones, merge operands, and snapshots when choosing the result.
 
 ![Get in normal LSM](get-normal-lsm.svg)
 
-In the scenario of key-value separation, the reading path differs from the normal LSM tree.
+With key-value separation, the read path gains an out-of-line value lookup.
 
 ## BadgerDB
 
 ![Get in BadgerDB](get-badger.svg)
 
-As shown in the above figure, in BadgerDB, due to the problem that newly-written data may be placed below previously-written data, each read operation needs to scan all levels. After traversing the memtable + L0 + one of the SSTs in each level, the latest version of the value can be accessed, and based on the vptr, accessing the vLog.
+Badger generally searches the memtables and LSM levels for the newest version at or below the read timestamp; an exact requested timestamp can end the search early. It then decodes the vptr and reads an out-of-line value directly from the vLog.
 
-During the scanning process, since the value in vLog is stored in the order of writes, sequential scanning is likely to become random reads on vLog. In order to avoid the performance degradation of scanning, BadgerDB will pre-fetch the value of the next entry from the disk before the user accesses the next value through an iterator. Thus, it effectively utilizes the bandwidth of the SSD and improves scan performance.
+Badger's iterator walks keys in sorted order, while values above the configured threshold occupy write-order offsets in the vLog. If write order and key order differ, a range scan that materializes those values can lose spatial locality. Badger mitigates this with configurable value prefetch: the checked v4.9.6 defaults fetch a window of 100 iterator values concurrently, while key-only or sparse scans can disable prefetch and fetch selected values on demand. This is a workload-dependent tradeoff, not proof that every Badger range scan is slow; insertion order, value size and threshold, cache state, scan length, compression, prefetch settings, and the storage device all affect the result.
+
+Historically, Badger's 2017 launch benchmark found value-materializing range iteration slower than RocksDB on one AWS i3.large setup despite prefetch, and left the shortfall as an open optimization problem. WiscKey's FAST '16 results were also conditional: with a randomly loaded database, tiny values lost to LevelDB on a long scan, while larger values won. These measurements explain the concern but do not establish a current cross-engine ranking.
 
 ## TerarkDB
 
 ![Get in TerarkDB](get-terarkdb.svg)
 
-As shown in the above figure, in TerarkDB, it first needs to find the v-SST file corresponding to the key in the LSM tree. Then, it accesses the latest v-SST based on the dependency relationship and finds the corresponding key in the index of v-SST, and then accesses the value.
+TerarkDB first finds the v-SST file number in the LSM tree. It follows any dependency relationship to the latest v-SST, uses that file's index to locate the key, and then reads the value.
 
 ## Titan and BlobDB
 
 ![Get in Titan](get-titan.svg)
 
-Titan and BlobDB need to find vptr from the LSM tree when reading, and then accesses the corresponding blob file.
+Titan and BlobDB find the vptr in the LSM tree and then read the corresponding record from a blob file.
 
 ## Comparison of Read Paths
 
-| Storage Engine | BadgerDB           | TerarkDB            | Titan / BlobDB             |
-| -------------- | ------------------ | ------------------- | ------------------ |
-| Scan Performance | Poor, requires prefetch | Good | Good |
-| Point Read (key) | Needs to access all levels | Stops at the first encounter | Stops at the first encounter |
-| Read Value | Reads directly using offset | Needs to access v-SST index | Reads directly using offset |
+<div class="table-container">
+
+| Storage Engine | BadgerDB | TerarkDB | Titan / BlobDB |
+| --- | --- | --- | --- |
+| Out-of-line value locality during a key-ordered scan | Write-order vLog offsets; configurable value prefetch | Key-sorted v-SST blocks; indexed lookup | Key-sorted blob records; direct pointer lookup |
+| Point lookup in the LSM | Generally searches for the newest visible version; an exact timestamp may stop early | Resolves the newest visible entry, then follows any v-SST dependency | Uses RocksDB's visible-entry lookup |
+| Out-of-line value lookup | Direct by offset and length | Through the v-SST index | Direct by offset and size |
+
+</div>
+
+These mechanisms expose different locality and CPU/I/O tradeoffs; they are not a benchmark ranking. A performance comparison must pin engine versions, value thresholds, load order, scan length, cache state, prefetch settings, compression, and hardware.
 
 # Alternative Implementation -- Neon Page Server
 
-Besides implementing a full key-value separation strategy in the storage engine, it is also possible to implement a specialized engine that has some capability of separating key and large values and targets one kind of workload.
+A specialized engine can apply the same broad idea to one workload without implementing a general-purpose key-value separation scheme.
 
-[Neon](https://neon.tech)'s page server, the underlying storage engine of Neon's serverless Postgres service, implements an LSM-like structure that separates Postgres pages and redo log entries. The storage engine stores each entry of Postgres redo logs and each Postgres page at a given timestamp as key-value pairs. The engine leverages the property that redo logs are generally small while pages are large 8-kilobyte values. Managing these two kinds of data separately can reduce write amplification compared with using a general-purpose LSM-tree storage engine.
+[Neon](https://neon.com)'s page server, the underlying storage engine of Neon's serverless Postgres service, uses an LSM-like structure for Postgres page-version history. Redo information is generally smaller than a materialized 8 KiB page. Managing incremental history and page images as different layer types can reduce write amplification compared with eagerly materializing every page version in a general-purpose LSM-tree layout.
 
 ![Neon page server](neon-pg-server.svg)
 
-As in the above figure, the WAL service streams logs to the page server. The page server stores WALs as in-memory layers. Then, these in-memory layers are flushed to the disk as delta/image layers. Redo logs are stored in delta layers, and 8K pages are stored in image layers. While the compaction process merges or repartitions the delta layers, the image layers can be left untouched and be processed or garbage-collected separately.
+As shown above, the Safekeeper streams WAL to the page server. The page server decodes incoming PostgreSQL WAL into per-key versions in an open in-memory layer. A frozen in-memory layer flushes to a delta layer, which may contain WAL records or page images over key and LSN ranges. Separately, image compaction materializes a snapshot of all keys in a key range at one LSN into an image layer. Keeping deltas and materialized images as distinct layer types lets Neon compact or repartition recent history and create or garbage-collect image snapshots on different schedules.
 
 # Summary
 
-Key-value separation in LSM trees can reduce the write amplification of storage engines. However, at the same time, it also brings additional costs in other areas, such as space amplification, impact on foreground write performance, impact on compression ratio, more complex read path, and the need for scanning all levels in the LSM structure. There are tradeoffs in each of the key-value separation design, and developers will need to choose a suitable key-value separation engine based on their workloads.
+Key-value separation can reduce LSM-tree write amplification, but it introduces other costs: more complex garbage collection and read paths, an extra out-of-line lookup, possible foreground-write interference, different compression behavior, and potentially weaker range-scan locality. Each design makes different tradeoffs, so developers should choose an engine according to their workload rather than treating separation as a universal improvement.
 
-## Reference
+## References
 
 * [WiscKey: Separating Keys from Values in SSD-conscious Storage](https://www.usenix.org/conference/fast16/technical-sessions/presentation/lu)
-* [dgraph-io/badger: Fast key-value DB in Go.](https://github.com/dgraph-io/badger)
-* [Introducing Badger: A fast key-value store written purely in Go](https://blog.dgraph.io/post/badger/)
-* [bytedance/terarkdb: A RocksDB compatible KV storage engine with better performance](https://github.com/bytedance/terarkdb)
-* [TerarkDB All-In-One Docs](https://bytedance.feishu.cn/docs/doccnZmYFqHBm06BbvYgjsHHcKc#)
-* [tikv/titan: A RocksDB plugin for key-value separation, inspired by WiscKey](https://github.com/tikv/titan/tree/master)
+* [BadgerDB source](https://github.com/dgraph-io/badger)
+* [Badger value-pointer layout](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/structs.go#L15-L18), [discard accounting](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/levels.go#L702-L715), and [value-log GC API](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/db.go#L1261-L1306)
+* [Badger iterator defaults and prefetch implementation](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/iterator.go) and [the tombstone-retention fix](https://github.com/dgraph-io/badger/commit/34dba21bea3683c83684bb9f40d3495976e2828a)
+* [Introducing Badger: a fast key-value store written purely in Go](https://discuss.dgraph.io/t/introducing-badger-a-fast-key-value-store-written-natively-in-go-dgraph-blog/1688)
+* [TerarkDB source at the reviewed revision](https://github.com/bytedance/terarkdb/tree/110bbecf61f3e4ef194e81cad1786f899c730752)
+* [Titan: a RocksDB plugin for key-value separation](https://github.com/tikv/titan)
+* [Titan blob-index format](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/src/blob_format.h#L134-L167) and [Level Merge option](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/include/titan/options.h)
 * [Design and Implementation of Titan](https://www.pingcap.com/blog/titan-storage-engine-design-and-implementation/)
-* [Deep dive into Neon storage engine](https://neon.tech/blog/get-page-at-lsn)
+* [RocksDB BlobDB index format](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/db/blob/blob_index.h#L24-L45), [options](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/include/rocksdb/advanced_options.h#L1082-L1162), and [integrated BlobDB design](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/docs/_posts/2021-05-26-integrated-blob-db.markdown)
+* [Neon page-server storage](https://github.com/neondatabase/neon/blob/8f60b04da47ffefe0e52bda2440134b42874eb75/docs/pageserver-storage.md) and [compaction](https://github.com/neondatabase/neon/blob/8f60b04da47ffefe0e52bda2440134b42874eb75/docs/pageserver-compaction.md)
 
-This blog post was originally posted on [08/07/2021](https://www.skyzh.dev/blog/2021-08-07-lsm-kv-separation-overview/) in Simplified Chinese. This is translated by ChatGPT with extra content on RocksDB's BlobDB and Neon's page server.
+This blog post was originally published in Simplified Chinese on [August 7, 2021](https://www.skyzh.dev/blog/2021-08-07-lsm-kv-separation-overview/). The English version was translated with ChatGPT and adds material on RocksDB's BlobDB and Neon's page server.
 
 Feel free to comment and share your thoughts on the corresponding [GitHub Discussion](https://github.com/skyzh/skyzh-site/discussions/28) for this blog post.

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -119,7 +119,7 @@ Once large values live outside the LSM tree, the engine needs a separate way to 
 
 Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger persists these statistics in the `DISCARD` file.
 
-Applications start collection explicitly. Badger uses the discard statistics to select a vLog file, copies its live values into a new file, and writes their updated pointers back to the LSM tree.
+As shown in the above figure, applications start collection explicitly. Badger uses the discard statistics to select a vLog file, then checks each record against the LSM tree. It skips a record if its key is gone or the current LSM entry no longer points to it. Badger copies the remaining live values into a new file and writes their updated pointers back to the LSM tree.
 
 Because those replacement pointers use the normal LSM write path, GC adds write traffic and must not overwrite a concurrent update or deletion.
 
@@ -135,7 +135,7 @@ TerarkDB rewrites live entries into new v-SSTs and records dependencies from old
 
 ![Compaction in TerarkDB](compaction-terarkdb.svg)
 
-During LSM-tree compaction, TerarkDB also refreshes file numbers. If the referenced v-SST has been replaced, the engine follows the dependency relationship and writes the new file number into the compaction output.
+As shown in the above figure, TerarkDB first selects the levels and files for an LSM-tree compaction. While merging those SSTs, it checks each separated value's v-SST file number. If the referenced v-SST has been replaced, TerarkDB follows the dependency relationship and writes the new file number into the compaction output before adding the new SSTs to the LSM tree.
 
 Over time, lower LSM levels may depend on many v-SSTs, and one v-SST may be referenced by many SSTs. TerarkDB performs a special _rebuild_ compaction to bound and shorten these dependency chains.
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -233,7 +233,7 @@ With key-value separation, the read path gains an out-of-line value lookup.
 
 </div>
 
-Badger checks the memtables and every LSM level for the highest visible version. It then decodes the vptr and reads the value directly from the vLog.
+Badger checks candidates through the memtables and LSM levels for the highest visible version. It then decodes the vptr and reads the value directly from the vLog.
 
 Reading a separated value always adds one extra indirection. Badger's scan-specific drawback is different: values are appended in write order, so nearby keys can point to distant locations in the vLog, weakening spatial locality. Badger mitigates this with configurable value prefetch, which defaults to 100 values; scan performance still depends on the workload and write order.
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -192,7 +192,7 @@ With key-value separation, the read path gains an out-of-line value lookup.
 
 Badger generally searches the memtables and LSM levels for the newest version at or below the read timestamp; an exact requested timestamp can end the search early. It then decodes the vptr and reads an out-of-line value directly from the vLog.
 
-Badger's iterator returns keys in sorted order, but large values sit at write-order offsets in the vLog. When write order is random relative to key order, a range scan can lose locality and perform poorly. Badger mitigates this with configurable value prefetch, which defaults to 100 values; results still depend on the workload and write order.
+All key-value-separated designs add an out-of-line value lookup. Badger's range-scan risk is not that indirection itself: its append-oriented vLog places large values in write order while its iterator returns keys in key order. When those orders differ, a scan can lose spatial locality and perform poorly. Badger mitigates this with configurable value prefetch, which defaults to 100 values; results still depend on the workload and write order.
 
 ## TerarkDB
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -57,7 +57,11 @@ Moving data through every level while an LSM tree is still small would introduce
 
 BadgerDB writes large values directly to its value log (vLog), as shown below.
 
+<div class="wide-write-path-figure">
+
 ![Writing to Badger](write-badger.svg)
+
+</div>
 
 When a user writes a key-value pair to Badger, values below a configurable threshold stay inline in the LSM tree. For a value at or above the threshold, the write path is as follows:
 
@@ -76,7 +80,11 @@ Because a v-SST uses SST format, its large values are sorted by key and can use 
 
 ## Titan and BlobDB
 
+<div class="wide-write-path-figure">
+
 ![Writing to Titan / BlobDB](write-titan.svg)
+
+</div>
 
 Titan is a RocksDB plugin, so its foreground path follows RocksDB. Its background path resembles TerarkDB's, but it stores large values in blob files. A blob file contains key-value records in key order and compresses each record individually. For a separated value, Titan stores `<key, <fileno, offset, size>>` in the LSM tree.
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -87,6 +87,8 @@ During a background flush, TerarkDB separates entries according to value size. S
 
 Because a v-SST uses SST format, its large values are sorted by key and can use RocksDB's block-level compression.
 
+The pinned TerarkDB source defaults to a 512 B separation threshold. Its key-sorted, indexed v-SSTs can use block compression, which helps explain why separating smaller values is a reasonable design choice here. This is not a universal optimum: lowering the threshold moves more values out of the LSM tree, changing compaction work, compression opportunity, cache behavior, and read and scan I/O.
+
 ## Titan and BlobDB
 
 <div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Writing to Titan and BlobDB diagram">
@@ -103,13 +105,14 @@ BlobDB has a similar write path and also stores ordered values with per-record c
 
 <div class="table-container">
 
-| Storage Engine | BadgerDB | TerarkDB | Titan / BlobDB |
-| --- | --- | --- | --- |
-| Foreground writing of large values <br/> (affects write amplification) | Written directly to vLog | Written to WAL, then flushed to v-SST | Written to WAL, then flushed to blob file |
-| Value pointer contents | `<fid, len, offset>` | `<fileno>` | Titan: `<fileno, offset, size>`<br/>BlobDB: `<type, fileno, offset, size, compression>` |
-| Out-of-line value order <br/> (one input to key-range locality) | Write order | Key order | Key order |
-| Compression granularity <br/> (affects space amplification) | Per record | Per block | Per record |
-| Out-of-line storage includes an index | No | Yes | No |
+| Storage Engine | BadgerDB | TerarkDB | Titan | BlobDB |
+| --- | --- | --- | --- | --- |
+| Foreground writing of large values <br/> (affects write amplification) | Written directly to vLog | Written to WAL, then flushed to v-SST | Written to WAL, then flushed to blob file | Written to WAL, then flushed to blob file |
+| Value pointer contents | `<fid, len, offset>` | `<fileno>` | `<fileno, offset, size>` | `<type, fileno, offset, size, compression>` |
+| Out-of-line value order <br/> (one input to key-range locality) | Write order | Key order | Key order | Key order |
+| Out-of-line value compression | None in vLog | Per block when enabled | Per record when enabled (default none) | Per record when enabled (default none) |
+| Separation-threshold context | v2.2007.3: 1 KiB; v4.9.6: 1 MiB; configurable | 512 B; configurable | 4 KiB; configurable | 0 when blob files are enabled; configurable; blob files default off |
+| Out-of-line storage includes an index | No | Yes | No | No |
 
 </div>
 
@@ -145,7 +148,7 @@ Because those replacement pointers use the normal LSM write path, GC adds write 
 
 </div>
 
-As shown in the above figure, a deletion at version 10 can coexist with a GC pointer update for the older value at version 9. Badger keeps the deletion visible while the rewrite is active, and its version ordering makes the deletion the newest visible entry. Moving the older value therefore does not make the deleted key visible again.
+As shown in the above figure, a deletion at version 10 can coexist with a GC rewrite of the older value at version 9. Unlike an ordinary LSM lookup that can return after the first matching key in the newest SSTs, Badger searches the memtables and LSM levels for the highest visible version. The version-10 deletion therefore remains visible over the rewritten version-9 entry. While the rewrite is active, Badger also prevents compaction from discarding a newer tombstone.
 
 ## Compaction and Garbage Collection in TerarkDB
 
@@ -230,7 +233,7 @@ With key-value separation, the read path gains an out-of-line value lookup.
 
 </div>
 
-Badger finds the newest visible entry in the LSM tree, decodes its vptr, and reads the value directly from the vLog.
+Badger checks the memtables and every LSM level for the highest visible version. It then decodes the vptr and reads the value directly from the vLog.
 
 Reading a separated value always adds one extra indirection. Badger's scan-specific drawback is different: values are appended in write order, so nearby keys can point to distant locations in the vLog, weakening spatial locality. Badger mitigates this with configurable value prefetch, which defaults to 100 values; scan performance still depends on the workload and write order.
 
@@ -286,14 +289,14 @@ Key-value separation can reduce LSM-tree write amplification, but it introduces 
 ## References
 
 * [WiscKey: Separating Keys from Values in SSD-conscious Storage](https://www.usenix.org/conference/fast16/technical-sessions/presentation/lu)
-* [BadgerDB source](https://github.com/dgraph-io/badger)
+* [BadgerDB source](https://github.com/dgraph-io/badger), including [v2.2007.3 options](https://github.com/dgraph-io/badger/blob/v2.2007.3/options.go), [v2.2007.3 value-log encoding](https://github.com/dgraph-io/badger/blob/v2.2007.3/value.go), [v4.9.6 options](https://github.com/dgraph-io/badger/blob/v4.9.6/options.go), and [v4.9.6 value-log encoding](https://github.com/dgraph-io/badger/blob/v4.9.6/value.go)
 * [Badger value-pointer layout](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/structs.go#L15-L18), [discard accounting](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/levels.go#L702-L715), and [value-log GC API](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/db.go#L1261-L1306)
 * [Badger iterator and prefetch implementation](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/iterator.go)
-* [TerarkDB source](https://github.com/bytedance/terarkdb/tree/110bbecf61f3e4ef194e81cad1786f899c730752)
+* [TerarkDB source](https://github.com/bytedance/terarkdb/tree/110bbecf61f3e4ef194e81cad1786f899c730752), [options](https://github.com/bytedance/terarkdb/blob/110bbecf61f3e4ef194e81cad1786f899c730752/options/options.cc), and [v-SST table builder](https://github.com/bytedance/terarkdb/blob/110bbecf61f3e4ef194e81cad1786f899c730752/db/compaction_job.cc)
 * [Titan: a RocksDB plugin for key-value separation](https://github.com/tikv/titan)
-* [Titan blob-index format](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/src/blob_format.h#L134-L167) and [Level Merge option](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/include/titan/options.h)
+* [Titan blob-index format](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/src/blob_format.h#L134-L167), [blob-record encoding](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/src/blob_format.cc), and [threshold, compression, and Level Merge options](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/include/titan/options.h)
 * [Design and Implementation of Titan](https://www.pingcap.com/blog/titan-storage-engine-design-and-implementation/)
-* [RocksDB BlobDB index format](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/db/blob/blob_index.h#L24-L45), [options](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/include/rocksdb/advanced_options.h#L1082-L1162), and [integrated BlobDB design](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/docs/_posts/2021-05-26-integrated-blob-db.markdown)
+* [RocksDB BlobDB index format](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/db/blob/blob_index.h#L24-L45), [options](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/include/rocksdb/advanced_options.h#L1082-L1162), [blob-record builder](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/db/blob/blob_file_builder.cc), and [integrated BlobDB design](https://github.com/facebook/rocksdb/blob/1dfa7297933df05237ac11376d6cb69d32591b1d/docs/_posts/2021-05-26-integrated-blob-db.markdown)
 * [Neon page-server storage](https://github.com/neondatabase/neon/blob/8f60b04da47ffefe0e52bda2440134b42874eb75/docs/pageserver-storage.md) and [compaction](https://github.com/neondatabase/neon/blob/8f60b04da47ffefe0e52bda2440134b42874eb75/docs/pageserver-compaction.md)
 
 This blog post was originally published in Simplified Chinese on [August 7, 2021](https://www.skyzh.dev/blog/2021-08-07-lsm-kv-separation-overview/). The English version was translated with ChatGPT and adds material on RocksDB's BlobDB and Neon's page server.

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -44,7 +44,11 @@ In this article, unless otherwise stated, we assume that the storage engine has 
 
 ## Without Key-Value Separation
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Writing to LSM diagram">
+
 ![Writing to LSM](write-normal-lsm.svg)
+
+</div>
 
 First, let's look at how a conventional LSM storage engine handles writes. When the engine receives a write, it records the key-value pair in both the memtable and the WAL (Write-Ahead Log). The memtable often uses a skip list. The WAL makes the memtable's contents recoverable after a server failure; once the required WAL record is durable, the engine can acknowledge the write as persisted.
 
@@ -58,7 +62,7 @@ Moving data through every level while an LSM tree is still small would introduce
 
 BadgerDB writes large values directly to its value log (vLog), as shown below.
 
-<div class="wide-write-path-figure">
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Writing to Badger diagram">
 
 ![Writing to Badger](write-badger.svg)
 
@@ -71,7 +75,11 @@ When a user writes a key-value pair to Badger, values below a configurable thres
 
 ## TerarkDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Writing to TerarkDB diagram">
+
 ![Writing to TerarkDB](write-terarkdb.svg)
+
+</div>
 
 Because TerarkDB is based on RocksDB, its foreground write path follows RocksDB: key-value pairs enter the memtable and WAL, and the memtable is later flushed to disk. Compared with Badger's direct vLog path, a large value is written once to the WAL and again to the v-SST (Value SST) during the flush, adding one full-value write.
 
@@ -81,7 +89,7 @@ Because a v-SST uses SST format, its large values are sorted by key and can use 
 
 ## Titan and BlobDB
 
-<div class="wide-write-path-figure">
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Writing to Titan and BlobDB diagram">
 
 ![Writing to Titan / BlobDB](write-titan.svg)
 
@@ -109,13 +117,21 @@ BlobDB has a similar write path and also stores ordered values with per-record c
 
 After users update or delete keys, a conventional LSM engine can discard obsolete records during compaction, as shown below. It can drop an old version or tombstone once no snapshot or lower-level data still needs it.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Compaction in normal LSM diagram">
+
 ![Compaction in normal LSM](compaction-normal-lsm.svg)
+
+</div>
 
 Once large values live outside the LSM tree, the engine needs a separate way to reclaim obsolete records and control space amplification.
 
 ## Garbage Collection in BadgerDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Garbage collection in Badger diagram">
+
 ![Garbage collection in Badger](gc-badger.svg)
+
+</div>
 
 Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger persists these statistics in the `DISCARD` file.
 
@@ -123,17 +139,29 @@ As shown in the above figure, applications start collection explicitly. Badger u
 
 Because those replacement pointers use the normal LSM write path, GC adds write traffic and must not overwrite a concurrent update or deletion.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Garbage collection consistency in Badger diagram">
+
 ![Garbage collection consistency in Badger](gc-consistency-badger.svg)
+
+</div>
 
 As shown in the above figure, a deletion at version 10 can coexist with a GC pointer update for the older value at version 9. Badger keeps the deletion visible while the rewrite is active, and its version ordering makes the deletion the newest visible entry. Moving the older value therefore does not make the deleted key visible again.
 
 ## Compaction and Garbage Collection in TerarkDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Garbage collection in TerarkDB diagram">
+
 ![Garbage collection in TerarkDB](gc-terarkdb.svg)
+
+</div>
 
 As shown in the above figure, TerarkDB uses each v-SST's garbage estimate to choose files for collection. It checks each record against the LSM tree, writes the live values into new v-SSTs, and records dependencies from the old files to their replacements. A read that still points to an old v-SST follows the dependency to the latest file, so GC does not have to write every replacement file number through the foreground path.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Compaction in TerarkDB diagram">
+
 ![Compaction in TerarkDB](compaction-terarkdb.svg)
+
+</div>
 
 As shown in the above figure, TerarkDB first selects the levels and files for an LSM-tree compaction. While merging those SSTs, it checks each separated value's v-SST file number. If the referenced v-SST has been replaced, TerarkDB follows the dependency relationship and writes the new file number into the compaction output before adding the new SSTs to the LSM tree.
 
@@ -143,19 +171,31 @@ Over time, lower LSM levels may depend on many v-SSTs, and one v-SST may be refe
 
 Titan's regular garbage collection resembles Badger's: statistics identify candidate blob files, Titan rewrites their live records, and it writes new vptrs back to the LSM tree. The process is shown below.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Regular garbage collection in Titan diagram">
+
 ![Regular garbage collection in Titan](gc-titan-regular.svg)
+
+</div>
 
 Regular GC synchronizes pointer updates with foreground writes so it cannot overwrite later values. This can affect write throughput.
 
 Titan also offers _Level Merge_, which is off by default. When enabled, compaction into the last two LSM levels can rewrite blob records and place updated blob indexes directly in the compaction output, avoiding a separate regular-GC pointer write-back.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Level-merge garbage collection in Titan diagram">
+
 ![Level-merge garbage collection in Titan](gc-titan-level-merge.svg)
+
+</div>
 
 ## Garbage Collection in BlobDB
 
 BlobDB integrates garbage collection with LSM compaction. An age cutoff selects older blob files that may be rewritten, while a separate force threshold can trigger targeted compaction when enough space can be reclaimed.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Compaction in BlobDB diagram">
+
 ![Compaction in BlobDB](compaction-blobdb.svg)
+
+</div>
 
 Blob files are not compacted independently. Live blobs move only when LSM compaction processes their referencing SST entries.
 
@@ -174,13 +214,21 @@ Blob files are not compacted independently. Live blobs move only when LSM compac
 
 For a point lookup, an LSM engine may inspect memtables, overlapping level-0 files, and one candidate file in each lower level. Bloom filters, caches, and indexes help it skip work and find the newest visible value.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Get in normal LSM diagram">
+
 ![Get in normal LSM](get-normal-lsm.svg)
+
+</div>
 
 With key-value separation, the read path gains an out-of-line value lookup.
 
 ## BadgerDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Get in BadgerDB diagram">
+
 ![Get in BadgerDB](get-badger.svg)
+
+</div>
 
 Badger finds the newest visible entry in the LSM tree, decodes its vptr, and reads the value directly from the vLog.
 
@@ -188,13 +236,21 @@ Reading a separated value always adds one extra indirection. Badger's scan-speci
 
 ## TerarkDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Get in TerarkDB diagram">
+
 ![Get in TerarkDB](get-terarkdb.svg)
+
+</div>
 
 TerarkDB first finds the v-SST file number in the LSM tree. It follows any dependency relationship to the latest v-SST, uses that file's index to locate the key, and then reads the value.
 
 ## Titan and BlobDB
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Get in Titan diagram">
+
 ![Get in Titan](get-titan.svg)
+
+</div>
 
 Titan and BlobDB find the vptr in the LSM tree and then read the corresponding record from a blob file.
 
@@ -215,7 +271,11 @@ A specialized engine can apply the same broad idea to one workload without imple
 
 [Neon](https://neon.com)'s page server, the underlying storage engine of Neon's serverless Postgres service, uses an LSM-like structure for Postgres page-version history. Redo information is generally smaller than a materialized 8 KiB page. Managing incremental history and page images as different layer types can reduce write amplification compared with eagerly materializing every page version in a general-purpose LSM-tree layout.
 
+<div class="labeled-figure-scroller" tabindex="0" role="region" aria-label="Neon page server diagram">
+
 ![Neon page server](neon-pg-server.svg)
+
+</div>
 
 Neon streams WAL to the page server, which builds page-version history in memory and flushes it to delta layers. The page server can also materialize image layers containing complete page snapshots at a chosen point in the log. Keeping history and snapshots separate lets Neon compact them on different schedules.
 

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -25,11 +25,11 @@ The idea sounds straightforward, but a practical implementation must answer seve
 * When reclaiming garbage, how should the engine update vptrs in the LSM tree?
 * How should the engine manage the effect of key-value separation on range scans?
 
-Between WiscKey's publication in 2016 and this English article in 2023, several key-value-separated LSM storage engines emerged. In this article, I will introduce four open-source implementations and compare their design tradeoffs. These differences can help readers choose an engine for workloads with large values.
+Several key-value-separated LSM storage engines have emerged since WiscKey. In this article, I will introduce four open-source implementations and compare their design tradeoffs. These differences can help readers choose an engine for workloads with large values.
 
 * [BadgerDB](https://github.com/dgraph-io/badger) is the closest of these engines to the key-value separation described in the WiscKey paper. It is written in Go and was developed for the Dgraph graph database.
-* [TerarkDB](https://github.com/bytedance/terarkdb) was developed by Terark, which ByteDance acquired. The checked source is a fork of RocksDB 5.18.3.
-* [Titan](https://github.com/tikv/titan) is a RocksDB plugin used by TiKV. Its repository documents compatibility with specific TiKV and RocksDB versions rather than promising compatibility with every RocksDB interface.
+* [TerarkDB](https://github.com/bytedance/terarkdb) was developed by Terark, which ByteDance acquired, and is based on RocksDB.
+* [Titan](https://github.com/tikv/titan) is a RocksDB plugin used by TiKV.
 * [BlobDB](https://github.com/facebook/rocksdb/tree/main/db/blob) is integrated into RocksDB and stores large values in separate blob files.
 
 <div style={{ "border": "1px solid", "padding": "0.5em" }}>
@@ -48,11 +48,11 @@ In this article, unless otherwise stated, we assume that the storage engine has 
 
 First, let's look at how a conventional LSM storage engine handles writes. When the engine receives a write, it records the key-value pair in both the memtable and the WAL (Write-Ahead Log). The memtable often uses a skip list. The WAL makes the memtable's contents recoverable after a server failure; once the required WAL record is durable, the engine can acknowledge the write as persisted.
 
-The engine performs two main kinds of background work: flushing memtables to disk and compacting the LSM tree. There is typically one mutable memtable per column family and there may be several immutable memtables waiting to flush. When a memtable reaches its size limit, the engine turns it into an SST and writes it to disk. A WAL can be removed only after no live memtable depends on it. An SST stores ordered key-value pairs in data blocks, often with per-block compression. Its index entries delimit those blocks and direct lookups to candidate blocks. SSTs may also contain structures such as Bloom filters to avoid unnecessary reads.
+The engine performs two main kinds of background work: flushing memtables to disk and compacting the LSM tree. It may have one mutable memtable and several immutable memtables waiting to flush. When a memtable reaches its size limit, the engine writes it as an SST; its WAL can be removed after no live memtable depends on it. An SST stores ordered key-value pairs in compressed blocks, with indexes and often Bloom filters to speed up reads.
 
 Level 0 of the LSM tree consists of multiple SST files whose key ranges may overlap. In a leveled design, files within each level from level 1 onward have non-overlapping key ranges. If a level exceeds its size limit, the storage engine compacts selected files with overlapping files in the next level. As a result, data generally moves toward lower levels over time.
 
-Moving data through every level while an LSM tree is still small would introduce unnecessary write amplification. Many engines therefore choose a dynamic base level (Lbase) according to the current database size and configuration. Early data can move directly from level 0 to that base level instead of passing through every intermediate level.
+Moving data through every level while an LSM tree is still small would introduce unnecessary write amplification. Many engines therefore choose a dynamic base level (Lbase), allowing early data to move there directly from level 0.
 
 ## BadgerDB
 
@@ -77,7 +77,7 @@ Because TerarkDB is based on RocksDB, its foreground write path follows RocksDB:
 
 During a background flush, TerarkDB separates entries according to value size. Small values remain with their keys in an SST. Large values and their keys are written to a v-SST. Because the v-SST has index blocks, a query can locate a value by key. For a separated value, the LSM tree stores the key and the v-SST file number, `<key, fileno>`, without an offset.
 
-Because a v-SST uses SST format, its large values are sorted by key and can use RocksDB's block-level compression. The pinned TerarkDB source sets its separation threshold to 512 B. Thresholds in these engines are configurable and version-dependent, so the comparison table below does not present them as timeless defaults.
+Because a v-SST uses SST format, its large values are sorted by key and can use RocksDB's block-level compression.
 
 ## Titan and BlobDB
 
@@ -89,7 +89,7 @@ Because a v-SST uses SST format, its large values are sorted by key and can use 
 
 Titan is a RocksDB plugin, so its foreground path follows RocksDB. Its background path resembles TerarkDB's, but it stores large values in blob files. A blob file contains key-value records in key order and compresses each record individually. For a separated value, Titan stores `<key, <fileno, offset, size>>` in the LSM tree.
 
-BlobDB has a similar write path and also stores ordered, per-record-compressed values in blob files. Its LSM blob index contains the record type, file number, offset, size, and compression metadata (and an expiration field for TTL values).
+BlobDB has a similar write path and also stores ordered, per-record-compressed values in blob files. Its LSM blob index contains the record type, file number, offset, size, and compression metadata.
 
 ## Comparison of Write Paths
 
@@ -107,7 +107,7 @@ BlobDB has a similar write path and also stores ordered, per-record-compressed v
 
 # Garbage Collection
 
-After users update or delete keys, a conventional LSM engine can discard obsolete records during compaction, as shown below. If compaction finds several versions of a key or a deletion tombstone, it drops old versions and tombstones only when no supported snapshot or lower-level data can still require them.
+After users update or delete keys, a conventional LSM engine can discard obsolete records during compaction, as shown below. It can drop an old version or tombstone once no snapshot or lower-level data still needs it.
 
 ![Compaction in normal LSM](compaction-normal-lsm.svg)
 
@@ -119,23 +119,19 @@ Once large values live outside the LSM tree, the engine needs a separate way to 
 
 Badger estimates reclaimable space when LSM compaction drops an obsolete entry whose value is stored in the vLog. At that point, it adds the referenced value's byte length to the discard statistic for that vLog file. Badger persists these statistics in the `DISCARD` file.
 
-Applications decide when to call `RunValueLogGC(discardRatio)`. The discard statistics guide selection of at most one candidate file per call; they do not trigger a rewrite automatically. During a rewrite, Badger checks each record's exact internal key/version and current LSM value pointer. It skips records that have been deleted, superseded, or no longer point to that location. Live values are appended to a new vLog file, and their updated pointers are written back to the LSM tree.
+Applications start collection explicitly. Badger uses the discard statistics to select a vLog file, copies its live values into a new file, and writes their updated pointers back to the LSM tree.
 
-Because those replacement pointers use the normal LSM write path, GC adds write traffic and can affect foreground throughput. It also raises a correctness question: could GC write an older value back after a concurrent update or deletion?
+Because those replacement pointers use the normal LSM write path, GC adds write traffic and must not overwrite a concurrent update or deletion.
 
 ![Garbage collection consistency in Badger](gc-consistency-badger.svg)
 
-*Correctness boundary: while a vLog rewrite is active, a newer tombstone must remain in the LSM so it continues to shadow any older value pointer written back by GC.*
-
-Badger's internal keys contain a user key and version. GC writes an older internal key/version back with a new value pointer, so a newer update or tombstone must continue to win. Badger reads the newest visible version across the LSM. The checked 2026 source also prevents last-level compaction from discarding a tombstone created after a vLog rewrite began. That retention rule is necessary: older releases could resurrect a deleted value in a narrow compaction/GC race, which was fixed in June 2026.
+*GC may move an old value, but reads still return the newest visible version.*
 
 ## Compaction and Garbage Collection in TerarkDB
 
 ![Garbage collection in TerarkDB](gc-terarkdb.svg)
 
-In TerarkDB, v-SST garbage collection does not need to write replacement pointers back through the foreground LSM write path, reducing its impact on foreground traffic.
-
-In the background, TerarkDB selects v-SSTs according to their estimated garbage and checks each key against the LSM tree to see whether it has been deleted or updated. GC produces new v-SSTs and records dependencies between old and new files in the MANIFEST. If a lookup points to an older v-SST, TerarkDB follows those dependencies to the newest file and reads the value there. This design avoids writing every replacement file number through the foreground path.
+TerarkDB rewrites live entries into new v-SSTs and records dependencies from old files to their replacements. Reads follow those dependencies, so GC does not need to write every replacement file number through the foreground path.
 
 ![Compaction in TerarkDB](compaction-terarkdb.svg)
 
@@ -149,23 +145,19 @@ Titan's regular garbage collection resembles Badger's: statistics identify candi
 
 ![Regular garbage collection in Titan](gc-titan-regular.svg)
 
-Because Titan is a RocksDB plugin, it does not have direct access to every key's internal version. When writing replacement pointers, it registers a `WriteCallback` to prevent GC from overwriting a later user update. This adds write-path synchronization and can affect throughput; the magnitude depends on the workload.
+Regular GC synchronizes pointer updates with foreground writes so it cannot overwrite later values. This can affect write throughput.
 
-Titan also offers an optional scheme called _Level Merge_, shown below. When enabled, compaction into the last two LSM levels can rewrite blob records and place updated blob indexes directly in the compaction output, avoiding a separate regular-GC pointer write-back.
+Titan also offers _Level Merge_, which is off by default. When enabled, compaction into the last two LSM levels can rewrite blob records and place updated blob indexes directly in the compaction output, avoiding a separate regular-GC pointer write-back.
 
 ![Level-merge garbage collection in Titan](gc-titan-level-merge.svg)
 
-Level Merge is off by default.
-
 ## Garbage Collection in BlobDB
 
-RocksDB's integrated BlobDB garbage collection is optional and compaction-integrated. When enabled, the age cutoff selects an oldest fraction of blob files whose references may be relocated during ordinary LSM compaction; the cutoff does not itself trigger compaction. A separate force threshold can schedule targeted leveled compactions when the garbage ratio among eligible files is high enough.
+BlobDB integrates garbage collection with LSM compaction. An age cutoff selects older blob files that may be rewritten, while a separate force threshold can trigger targeted compaction when enough space can be reclaimed.
 
 ![Compaction in BlobDB](compaction-blobdb.svg)
 
-Blob files are not compacted independently. Live blobs are relocated only as their referencing SST entries are processed during LSM compaction.
-
-*The figure shows eligible blob files being rewritten as part of LSM compaction, not a standalone blob-file compaction.*
+Blob files are not compacted independently. Live blobs move only when LSM compaction processes their referencing SST entries.
 
 ## Comparison of Garbage Collection Strategies
 
@@ -180,7 +172,7 @@ Blob files are not compacted independently. Live blobs are relocated only as the
 
 # Read Path of Large Values
 
-For a point lookup, an LSM engine may inspect memtables, overlapping level-0 files, and at most one candidate file in each non-overlapping lower level. Bloom filters, caches, indexes, and an early visible result can avoid many of these probes. The engine must still respect sequence numbers, tombstones, merge operands, and snapshots when choosing the result.
+For a point lookup, an LSM engine may inspect memtables, overlapping level-0 files, and one candidate file in each lower level. Bloom filters, caches, and indexes help it skip work and find the newest visible value.
 
 ![Get in normal LSM](get-normal-lsm.svg)
 
@@ -190,9 +182,9 @@ With key-value separation, the read path gains an out-of-line value lookup.
 
 ![Get in BadgerDB](get-badger.svg)
 
-Badger generally searches the memtables and LSM levels for the newest version at or below the read timestamp; an exact requested timestamp can end the search early. It then decodes the vptr and reads an out-of-line value directly from the vLog.
+Badger finds the newest visible entry in the LSM tree, decodes its vptr, and reads the value directly from the vLog.
 
-All key-value-separated designs add an out-of-line value lookup. Badger's range-scan risk is not that indirection itself: its append-oriented vLog places large values in write order while its iterator returns keys in key order. When those orders differ, a scan can lose spatial locality and perform poorly. Badger mitigates this with configurable value prefetch, which defaults to 100 values; results still depend on the workload and write order.
+Reading a separated value always adds one extra indirection. Badger's scan-specific drawback is different: values are appended in write order, so nearby keys can point to distant locations in the vLog, weakening spatial locality. Badger mitigates this with configurable value prefetch, which defaults to 100 values; scan performance still depends on the workload and write order.
 
 ## TerarkDB
 
@@ -213,12 +205,9 @@ Titan and BlobDB find the vptr in the LSM tree and then read the corresponding r
 | Storage Engine | BadgerDB | TerarkDB | Titan / BlobDB |
 | --- | --- | --- | --- |
 | Out-of-line value locality during a key-ordered scan | Write-order vLog offsets; configurable value prefetch | Key-sorted v-SST blocks; indexed lookup | Key-sorted blob records; direct pointer lookup |
-| Point lookup in the LSM | Generally searches for the newest visible version; an exact timestamp may stop early | Resolves the newest visible entry, then follows any v-SST dependency | Uses RocksDB's visible-entry lookup |
 | Out-of-line value lookup | Direct by offset and length | Through the v-SST index | Direct by offset and size |
 
 </div>
-
-These mechanisms expose different locality and CPU/I/O tradeoffs; they are not a benchmark ranking. A performance comparison must pin engine versions, value thresholds, load order, scan length, cache state, prefetch settings, compression, and hardware.
 
 # Alternative Implementation -- Neon Page Server
 
@@ -228,7 +217,7 @@ A specialized engine can apply the same broad idea to one workload without imple
 
 ![Neon page server](neon-pg-server.svg)
 
-As shown above, the Safekeeper streams WAL to the page server. The page server decodes incoming PostgreSQL WAL into per-key versions in an open in-memory layer. A frozen in-memory layer flushes to a delta layer, which may contain WAL records or page images over key and LSN ranges. Separately, image compaction materializes a snapshot of all keys in a key range at one LSN into an image layer. Keeping deltas and materialized images as distinct layer types lets Neon compact or repartition recent history and create or garbage-collect image snapshots on different schedules.
+Neon streams WAL to the page server, which builds page-version history in memory and flushes it to delta layers. The page server can also materialize image layers containing complete page snapshots at a chosen point in the log. Keeping history and snapshots separate lets Neon compact them on different schedules.
 
 # Summary
 
@@ -239,9 +228,8 @@ Key-value separation can reduce LSM-tree write amplification, but it introduces 
 * [WiscKey: Separating Keys from Values in SSD-conscious Storage](https://www.usenix.org/conference/fast16/technical-sessions/presentation/lu)
 * [BadgerDB source](https://github.com/dgraph-io/badger)
 * [Badger value-pointer layout](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/structs.go#L15-L18), [discard accounting](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/levels.go#L702-L715), and [value-log GC API](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/db.go#L1261-L1306)
-* [Badger iterator defaults and prefetch implementation](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/iterator.go) and [the tombstone-retention fix](https://github.com/dgraph-io/badger/commit/34dba21bea3683c83684bb9f40d3495976e2828a)
-* [Introducing Badger: a fast key-value store written purely in Go](https://discuss.dgraph.io/t/introducing-badger-a-fast-key-value-store-written-natively-in-go-dgraph-blog/1688)
-* [TerarkDB source at the reviewed revision](https://github.com/bytedance/terarkdb/tree/110bbecf61f3e4ef194e81cad1786f899c730752)
+* [Badger iterator and prefetch implementation](https://github.com/dgraph-io/badger/blob/fbd8d2eefad8be8757249767255faf989945b599/iterator.go)
+* [TerarkDB source](https://github.com/bytedance/terarkdb/tree/110bbecf61f3e4ef194e81cad1786f899c730752)
 * [Titan: a RocksDB plugin for key-value separation](https://github.com/tikv/titan)
 * [Titan blob-index format](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/src/blob_format.h#L134-L167) and [Level Merge option](https://github.com/tikv/titan/blob/b21afb5d7a50f960fbf47a19c103ebc6c43636a3/include/titan/options.h)
 * [Design and Implementation of Titan](https://www.pingcap.com/blog/titan-storage-engine-design-and-implementation/)

--- a/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
+++ b/src/content/blog/2023-12-31-lsm-kv-separation-overview.mdx
@@ -125,13 +125,13 @@ Because those replacement pointers use the normal LSM write path, GC adds write 
 
 ![Garbage collection consistency in Badger](gc-consistency-badger.svg)
 
-*GC may move an old value, but reads still return the newest visible version.*
+As shown in the above figure, a deletion at version 10 can coexist with a GC pointer update for the older value at version 9. Badger keeps the deletion visible while the rewrite is active, and its version ordering makes the deletion the newest visible entry. Moving the older value therefore does not make the deleted key visible again.
 
 ## Compaction and Garbage Collection in TerarkDB
 
 ![Garbage collection in TerarkDB](gc-terarkdb.svg)
 
-TerarkDB rewrites live entries into new v-SSTs and records dependencies from old files to their replacements. Reads follow those dependencies, so GC does not need to write every replacement file number through the foreground path.
+As shown in the above figure, TerarkDB uses each v-SST's garbage estimate to choose files for collection. It checks each record against the LSM tree, writes the live values into new v-SSTs, and records dependencies from the old files to their replacements. A read that still points to an old v-SST follows the dependency to the latest file, so GC does not have to write every replacement file number through the foreground path.
 
 ![Compaction in TerarkDB](compaction-terarkdb.svg)
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,12 +230,19 @@ h6 {
 	width: max-content;
 }
 
-.wide-write-path-figure {
+.labeled-figure-scroller {
 	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+	-webkit-overflow-scrolling: touch;
+}
+
+.labeled-figure-scroller:focus-visible {
+	outline: 2px solid var(--border-strong);
+	outline-offset: 0.25rem;
 }
 
 @media (max-width: 767px) {
-	.prose .wide-write-path-figure img {
+	.prose .labeled-figure-scroller img {
 		max-width: none;
 	}
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,6 +230,16 @@ h6 {
 	width: max-content;
 }
 
+.wide-write-path-figure {
+	overflow-x: auto;
+}
+
+@media (max-width: 767px) {
+	.prose .wide-write-path-figure img {
+		max-width: none;
+	}
+}
+
 .page-heading {
 	margin: 0;
 }


### PR DESCRIPTION
## Why

The key-value separation overview had source-fidelity errors in pointer formats, garbage collection, reads, and system-specific behavior, plus stale citations and narrow-screen presentation problems.

## What changed

Correct the generic LSM, Badger, TerarkDB, Titan, BlobDB, and Neon explanations against primary sources; restore the version-qualified threshold and compression-strategy comparison; explain Badger’s all-level version selection separately from tombstone retention; repair the Badger and Titan diagrams; refresh citations; and keep every labeled figure readable on narrow screens. The Badger scan section also distinguishes the indirection common to separated-value reads from Badger’s write-order locality tradeoff.

AI-Assisted: GPT-5.6 Sol + Sentinel
AI-Assisted: DeepSeek V4 Flash + Scholar
Reviewed-by: GPT-5.6 Sol + Oracle (consistency)
