### PR TITLE
Proofread RiseDev post

### DIFF
--- a/src/content/blog/2022-07-12-risedev.md
+++ b/src/content/blog/2022-07-12-risedev.md
@@ -6,6 +6,6 @@ description: "Developer Experience Counts: Behind the Scenes of RiseDev"
 external: true
 ---
 
-I’ve published a blog on our company’s website. In this blog, I talked about how we improved the development experience for the RisingWave project. Please take a look :)
+I published a post on our company’s website about how we improved the development experience for RisingWave. Please take a look :)
 
 [https://www.risingwave-labs.com/blog/developer-experience-counts-behind-the-scenes-of-RiseDev/](https://www.risingwave-labs.com/blog/developer-experience-counts-behind-the-scenes-of-RiseDev/)


### PR DESCRIPTION
## Why
The RiseDev post had a few awkward or repetitive sentences.

## What changed
- Before → after: consolidated the introductory announcement into one natural sentence and used the project name consistently.
- No technical claim, diagram, asset, or external URL target changed.

## Review note
The existing RisingWave URL redirects to a 404 as of this audit. It is intentionally unchanged because repairing an external target is outside this editorial-only PR.

AI-Assisted: GPT-5.6 Terra + Scholar
