### PR TITLE
Proofread MiniLSM post

### DIFF
--- a/src/content/blog/2022-12-27-mini-lsm.md
+++ b/src/content/blog/2022-12-27-mini-lsm.md
@@ -6,7 +6,7 @@ external: true
 description: "MiniLSM: Build an LSM-Tree Storage Engine in a Week"
 ---
 
-I’ve been working on a series of tutorial on how to build an LSM-Tree storage engine in the Rust programming language.
-The tutorial is published at [https://skyzh.github.io/mini-lsm](https://skyzh.github.io/mini-lsm), and the starter code
-plus reference solution is available at [https://github.com/skyzh/mini-lsm](https://github.com/skyzh/mini-lsm). Welcome
-to take a look!
+I’ve been working on a series of tutorials on how to build an LSM-Tree storage engine in Rust.
+The tutorials are published at [https://skyzh.github.io/mini-lsm](https://skyzh.github.io/mini-lsm), and the starter code
+and reference solution are available at [https://github.com/skyzh/mini-lsm](https://github.com/skyzh/mini-lsm). Take
+a look!


### PR DESCRIPTION
## Why
The MiniLSM post had singular/plural agreement and phrasing issues in its short introduction.

## What changed
- Before → after: changed “a series of tutorial” to “a series of tutorials” and made the linked course/code sentence agree grammatically.
- No technical claim, diagram, asset, or URL target changed.

AI-Assisted: GPT-5.6 Terra + Scholar
