### PR TITLE
Proofread the shared-indexes post

### DIFF
--- a/src/content/blog/2022-12-28-shared-state-in-risingwave.md
+++ b/src/content/blog/2022-12-28-shared-state-in-risingwave.md
@@ -6,8 +6,6 @@ description: "Shared Indexes and Joins in Streaming Databases"
 external: true
 ---
 
-This article is basically an English version of [my previous post](https://www.skyzh.dev/posts/articles/2022-05-29-shared-state-in-risingwave/), which was originally written in May 2022. This is also a summary of my
-undergraduate's thesis on streaming indexes and streaming joins. Now it is half a year later and the implementation
-in RisingWave has changed a lot. But the basic idea stays the same: push data to the remote node instead of pull.
+This article is an English version of [my previous post](https://www.skyzh.dev/posts/articles/2022-05-29-shared-state-in-risingwave/), which was originally published in May 2022. It also summarizes my undergraduate thesis on streaming indexes and streaming joins. Half a year has passed since then, and the implementation in RisingWave has changed significantly. But the basic idea remains the same: push data to the remote node instead of pulling it.
 
 [https://www.risingwave-labs.com/blog/shared-indexes-and-joins-in-streaming-databases/](https://www.risingwave-labs.com/blog/shared-indexes-and-joins-in-streaming-databases/)


### PR DESCRIPTION
## Why

The short English pointer post contained several grammar and agreement issues that made its provenance and summary harder to read.

## What changed

- Rephrased the publication-history sentence and corrected “undergraduate's thesis.”
- Smoothed the half-year transition and corrected singular/plural agreement.
- Changed “push data ... instead of pull” to “push data ... instead of pulling it.”
- Preserved the article's technical claim, external destination, metadata, and all unrelated site bytes.

## Validation

- `npm run check`
- `npm run build`
- External links returned HTTP 200 after redirects.
- `git diff --check` and exact one-file scope passed.
- Manually read the rendered post at 1440px and 390px. The existing shared narrow-layout clipping remains outside this post-only change.

AI-Assisted: GPT-5.6 Sol + Sentinel
