### PR TITLE
Polish key-value separation diagram labels

### DIFF
--- a/public/blog/2023-12-31-lsm-kv-separation-overview/compaction-blobdb.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/compaction-blobdb.svg
@@ -44,7 +44,7 @@
       </g>
       <g id="Graphic_142">
         <text transform="translate(345.89056 529.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Blob DB</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">BlobDB</tspan>
         </text>
       </g>
       <g id="Graphic_203">
@@ -125,7 +125,7 @@
       </g>
       <g id="Graphic_215">
         <text transform="translate(-116 420.63)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Select blobs files to garbage-collect, find all SSTs that </tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Select blob files to garbage-collect and find all SSTs that </tspan>
           <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="33.448">point to the blob files.</tspan>
         </text>
       </g>
@@ -158,7 +158,7 @@
       </g>
       <g id="Graphic_227">
         <text transform="translate(-110 697.375)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">3. Rewrite the blob files while compaction, store new vPtr in compacted files.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">3. Rewrite the blob files during compaction and store the new vptr in the compacted files.</tspan>
         </text>
       </g>
       <g id="Line_228">
@@ -198,7 +198,7 @@
       </g>
       <g id="Graphic_249">
         <text transform="translate(345.89056 872.776)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Blob DB</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">BlobDB</tspan>
         </text>
       </g>
       <g id="Graphic_248">
@@ -299,7 +299,7 @@
       </g>
       <g id="Graphic_276">
         <text transform="translate(345.89056 370.854)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Blob DB</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">BlobDB</tspan>
         </text>
       </g>
       <g id="Graphic_262">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/compaction-terarkdb.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/compaction-terarkdb.svg
@@ -228,7 +228,7 @@
       </g>
       <g id="Graphic_129">
         <text transform="translate(173.87234 552.1915)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">2. Merge files while updating file numbers, put new files into LSM.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">2. Merge files while updating file numbers, then put the new files into the LSM tree.</tspan>
         </text>
       </g>
       <g id="Graphic_132">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/gc-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/gc-badger.svg
@@ -218,22 +218,22 @@
       </g>
       <g id="Graphic_179">
         <text transform="translate(353.24165 746.5)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="12" fill="black" x="5684342e-19" y="11">Update vPtr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="12" fill="black" x="5684342e-19" y="11">Update vptr</tspan>
         </text>
       </g>
       <g id="Graphic_180">
         <text transform="translate(-95 471.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="15063506e-19" y="15">1. Select vLog files to GC</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="15063506e-19" y="15">1. Select vLog files for GC</tspan>
         </text>
       </g>
       <g id="Graphic_181">
         <text transform="translate(-139.828 587.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="27853275e-19" y="15">2.Scan LSM and write new vLog</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="27853275e-19" y="15">2. Scan LSM; write a new vLog</tspan>
         </text>
       </g>
       <g id="Graphic_182">
         <text transform="translate(-147.3 691.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">3. Write updated vptr to LSM tree</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">3. Update vptr in the LSM tree</tspan>
         </text>
       </g>
     </g>

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/gc-consistency-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/gc-consistency-badger.svg
@@ -187,7 +187,7 @@
       </g>
       <g id="Graphic_110">
         <text transform="translate(761.8195 387.58)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">GC process updates vPtr of A at ts=9</tspan>
+          <tspan font-family="Helvetica Neue" font-size="14" fill="black" x="0" y="13">GC process updates A's vptr at ts=9</tspan>
         </text>
       </g>
       <g id="Graphic_111">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/gc-titan-level-merge.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/gc-titan-level-merge.svg
@@ -125,7 +125,7 @@
       </g>
       <g id="Graphic_215">
         <text transform="translate(-110 484.078)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Compaction triggered in the LSM structure</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Trigger compaction in the LSM tree.</tspan>
         </text>
       </g>
       <g id="Graphic_217">
@@ -157,7 +157,7 @@
       </g>
       <g id="Graphic_227">
         <text transform="translate(-110 697.375)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">2. Rewrite the blob files while compaction, store new vPtr in compacted files.</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">2. Rewrite the blob files during compaction and store the new vptr in the compacted files.</tspan>
         </text>
       </g>
       <g id="Line_228">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/gc-titan-regular.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/gc-titan-regular.svg
@@ -219,12 +219,12 @@
       </g>
       <g id="Graphic_179">
         <text transform="translate(269.97948 739.875)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="12" fill="black" x="0" y="11">Register WriteCallback, and update vptr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="12" fill="black" x="0" y="11">Register WriteCallback and update vptr</tspan>
         </text>
       </g>
       <g id="Graphic_180">
         <text transform="translate(-91.404 471.026)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Select blob files to GC</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">1. Select blob files for GC</tspan>
         </text>
       </g>
       <g id="Graphic_181">
@@ -234,7 +234,7 @@
       </g>
       <g id="Graphic_182">
         <text transform="translate(-153.1 691.276)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="17337243e-19" y="15">3. Write updated vPtr to LSM tree</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="17337243e-19" y="15">3. Update vptr in the LSM tree</tspan>
         </text>
       </g>
     </g>

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/get-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/get-badger.svg
@@ -134,7 +134,7 @@
       </g>
       <g id="Graphic_55">
         <text transform="translate(536 474.22)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Retrieve vPtr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Retrieve vptr</tspan>
         </text>
       </g>
       <g id="Graphic_57">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/get-titan.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/get-titan.svg
@@ -134,7 +134,7 @@
       </g>
       <g id="Graphic_55">
         <text transform="translate(536 426)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Retrieve vPtr</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="0" y="15">Retrieve vptr</tspan>
         </text>
       </g>
       <g id="Graphic_57">

--- a/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
+++ b/public/blog/2023-12-31-lsm-kv-separation-overview/write-badger.svg
@@ -219,7 +219,7 @@
         <rect x="214.5" y="558.052" width="66.624" height="28.447998" fill="white"/>
         <rect x="214.5" y="558.052" width="66.624" height="28.447998" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(219.5 563.052)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6.832" y="15" xml:space="preserve">File Id</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" fill="black" x="6.832" y="15" xml:space="preserve">File ID</tspan>
         </text>
       </g>
       <g id="Graphic_55">


### PR DESCRIPTION
## Why

The article prose is already clean, but several directly owned SVG labels contained obvious grammar, punctuation, capitalization, and established-term inconsistencies.

## What changed

- Normalized non-semantic labels such as `BlobDB`, `vptr`, `File ID`, “blob files,” and “during compaction.”
- Fixed missing articles, punctuation, and the missing space in `2. Scan`.
- Render-checked every edited SVG and shortened two GC instructions so the corrected labels do not overlap diagram objects.
- Preserved all geometry and semantics. Potentially semantic Blob/v-SST and Badger/Titan pointer-field wording remains unchanged for owner review.

## Validation

- `npm run check`
- `npm run build`
- All 19 local assets exist; every external link returned HTTP 200 after redirects.
- `git diff --check` and exact nine-SVG scope passed.
- Manually inspected all nine edited SVGs directly and the full rendered article at 1440px and 390px; the existing shared narrow-layout clipping remains outside this asset-only change.

AI-Assisted: GPT-5.6 Sol + Sentinel
